### PR TITLE
Update resgroup option names for latest versions

### DIFF
--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -163,7 +163,7 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 			} else { // GPDB7+
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
-				someGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: "15", Cpuset: "-1"}, CpuMaxPercent: "10", CpuSoftPriority: "100"}
+				someGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: "15", Cpuset: "-1"}, CpuMaxPercent: "10", CpuWeight: "100"}
 				builtin.PrintCreateResourceGroupStatementsAtLeast7(backupfile, tocfile, []builtin.ResourceGroupAtLeast7{someGroup}, emptyMetadataMap)
 				testhelper.AssertQueryRuns(connectionPool, buffer.String())
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP some_group`)
@@ -200,7 +200,7 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
 				expectedDefaults := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: concurrencyDefault, Cpuset: cpuSetDefault},
-					CpuMaxPercent: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuWeight: "100"}
 
 				testhelper.AssertQueryRuns(connectionPool, "CREATE RESOURCE GROUP some_group WITH (CPU_MAX_PERCENT=10, CPU_WEIGHT=100);")
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP some_group`)
@@ -243,7 +243,7 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
 				expectedDefaults := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: concurrencyDefault, Cpuset: cpuSetDefault},
-					CpuMaxPercent: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuWeight: "100"}
 
 				testhelper.AssertQueryRuns(connectionPool, "CREATE RESOURCE GROUP some_group WITH (CPU_MAX_PERCENT=10, CPU_WEIGHT=100);")
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP some_group`)
@@ -285,7 +285,7 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
 				defaultGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "default_group", Concurrency: "15", Cpuset: "-1"},
-					CpuMaxPercent: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuWeight: "100"}
 				emptyMetadataMap := map[builtin.UniqueID]builtin.ObjectMetadata{}
 
 				builtin.PrintCreateResourceGroupStatementsAtLeast7(backupfile, tocfile, []builtin.ResourceGroupAtLeast7{defaultGroup}, emptyMetadataMap)

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -163,7 +163,7 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 			} else { // GPDB7+
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
-				someGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: "15", Cpuset: "-1"}, CpuHardQuotaLimit: "10", CpuSoftPriority: "100"}
+				someGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: "15", Cpuset: "-1"}, CpuMaxPercent: "10", CpuSoftPriority: "100"}
 				builtin.PrintCreateResourceGroupStatementsAtLeast7(backupfile, tocfile, []builtin.ResourceGroupAtLeast7{someGroup}, emptyMetadataMap)
 				testhelper.AssertQueryRuns(connectionPool, buffer.String())
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP some_group`)
@@ -200,9 +200,9 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
 				expectedDefaults := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: concurrencyDefault, Cpuset: cpuSetDefault},
-					CpuHardQuotaLimit: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuSoftPriority: "100"}
 
-				testhelper.AssertQueryRuns(connectionPool, "CREATE RESOURCE GROUP some_group WITH (CPU_HARD_QUOTA_LIMIT=10, CPU_SOFT_PRIORITY=100);")
+				testhelper.AssertQueryRuns(connectionPool, "CREATE RESOURCE GROUP some_group WITH (CPU_MAX_PERCENT=10, CPU_WEIGHT=100);")
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP some_group`)
 
 				resultResourceGroups := builtin.GetResourceGroups[builtin.ResourceGroupAtLeast7](connectionPool)
@@ -243,9 +243,9 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
 				expectedDefaults := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: concurrencyDefault, Cpuset: cpuSetDefault},
-					CpuHardQuotaLimit: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuSoftPriority: "100"}
 
-				testhelper.AssertQueryRuns(connectionPool, "CREATE RESOURCE GROUP some_group WITH (CPU_HARD_QUOTA_LIMIT=10, CPU_SOFT_PRIORITY=100);")
+				testhelper.AssertQueryRuns(connectionPool, "CREATE RESOURCE GROUP some_group WITH (CPU_MAX_PERCENT=10, CPU_WEIGHT=100);")
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP some_group`)
 
 				resultResourceGroups := builtin.GetResourceGroups[builtin.ResourceGroupAtLeast7](connectionPool)
@@ -285,7 +285,7 @@ var _ = Describe("cbcopy integration create statement tests", func() {
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
 				defaultGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: "default_group", Concurrency: "15", Cpuset: "-1"},
-					CpuHardQuotaLimit: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuSoftPriority: "100"}
 				emptyMetadataMap := map[builtin.UniqueID]builtin.ObjectMetadata{}
 
 				builtin.PrintCreateResourceGroupStatementsAtLeast7(backupfile, tocfile, []builtin.ResourceGroupAtLeast7{defaultGroup}, emptyMetadataMap)

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -185,7 +185,7 @@ var _ = Describe("cbcopy integration tests", func() {
 				results := builtin.GetResourceGroups[builtin.ResourceGroupAtLeast7](connectionPool)
 
 				someGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: `somegroup`, Concurrency: "15", Cpuset: "-1"},
-					CpuMaxPercent: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuWeight: "100"}
 
 				for _, resultGroup := range results {
 					if resultGroup.Name == `somegroup` {
@@ -242,7 +242,7 @@ var _ = Describe("cbcopy integration tests", func() {
 				results := builtin.GetResourceGroups[builtin.ResourceGroupAtLeast7](connectionPool)
 
 				expectedDefaults := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: `somegroup`, Concurrency: concurrencyDefault, Cpuset: cpuSetDefault},
-					CpuMaxPercent: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuWeight: "100"}
 
 				for _, resultGroup := range results {
 					if resultGroup.Name == `somegroup` {

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -179,13 +179,13 @@ var _ = Describe("cbcopy integration tests", func() {
 			} else { // GPDB7+
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
-				testhelper.AssertQueryRuns(connectionPool, `CREATE RESOURCE GROUP someGroup WITH (CPU_HARD_QUOTA_LIMIT=10, CPU_SOFT_PRIORITY=100, CONCURRENCY=15);`)
+				testhelper.AssertQueryRuns(connectionPool, `CREATE RESOURCE GROUP someGroup WITH (CPU_MAX_PERCENT=10, CPU_WEIGHT=100, CONCURRENCY=15);`)
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP someGroup`)
 
 				results := builtin.GetResourceGroups[builtin.ResourceGroupAtLeast7](connectionPool)
 
 				someGroup := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: `somegroup`, Concurrency: "15", Cpuset: "-1"},
-					CpuHardQuotaLimit: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuSoftPriority: "100"}
 
 				for _, resultGroup := range results {
 					if resultGroup.Name == `somegroup` {
@@ -236,13 +236,13 @@ var _ = Describe("cbcopy integration tests", func() {
 			} else {
 				return
 				/* comment out, due to CBDB/PG14 - GP7/PG12 behavior diff
-				testhelper.AssertQueryRuns(connectionPool, `CREATE RESOURCE GROUP someGroup WITH (CPU_HARD_QUOTA_LIMIT=10, CPU_SOFT_PRIORITY=100);`)
+				testhelper.AssertQueryRuns(connectionPool, `CREATE RESOURCE GROUP someGroup WITH (CPU_MAX_PERCENT=10, CPU_WEIGHT=100);`)
 				defer testhelper.AssertQueryRuns(connectionPool, `DROP RESOURCE GROUP someGroup`)
 
 				results := builtin.GetResourceGroups[builtin.ResourceGroupAtLeast7](connectionPool)
 
 				expectedDefaults := builtin.ResourceGroupAtLeast7{ResourceGroup: builtin.ResourceGroup{Oid: 1, Name: `somegroup`, Concurrency: concurrencyDefault, Cpuset: cpuSetDefault},
-					CpuHardQuotaLimit: "10", CpuSoftPriority: "100"}
+					CpuMaxPercent: "10", CpuSoftPriority: "100"}
 
 				for _, resultGroup := range results {
 					if resultGroup.Name == `somegroup` {

--- a/meta/builtin/extract_helper.go
+++ b/meta/builtin/extract_helper.go
@@ -324,7 +324,7 @@ func backupResourceGroups(conn *dbconn.DBConn, metadataFile *utils.FileWithByteC
 	gplog.Verbose("Writing CREATE RESOURCE GROUP statements to metadata file")
 
 	// at resource group part, CBDB is still same as 3x/GP6.
-	if (conn.Version.IsGPDB() && conn.Version.Before("7")) || conn.Version.IsCBDB() {
+	if (conn.Version.IsGPDB() && conn.Version.Before("7")) {
 		resGroups := GetResourceGroups[ResourceGroupBefore7](conn)
 		objectCounts["Resource Groups"] = len(resGroups)
 		resGroupMetadata := GetCommentsForObjectType(conn, TYPE_RESOURCEGROUP)

--- a/meta/builtin/metadata_globals_test.go
+++ b/meta/builtin/metadata_globals_test.go
@@ -264,7 +264,7 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 		It("prints prepare resource groups", func() {
 			builtin.PrintResetResourceGroupStatements(backupfile, tocfile)
 			testutils.ExpectEntry(tocfile.GlobalEntries, 0, "", "", "admin_group", "RESOURCE GROUP")
-			if (connectionPool.Version.IsGPDB() && connectionPool.Version.Before("7")) || connectionPool.Version.IsCBDB() {
+			if (connectionPool.Version.IsGPDB() && connectionPool.Version.Before("7")) {
 				testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 					`ALTER RESOURCE GROUP admin_group SET CPU_RATE_LIMIT 1;`,
 					`ALTER RESOURCE GROUP admin_group SET MEMORY_LIMIT 1;`,
@@ -272,12 +272,12 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 					`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 1;`)
 			} else { // GPDB7+
 				testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
-					`ALTER RESOURCE GROUP admin_group SET CPU_HARD_QUOTA_LIMIT 1;`,
-					`ALTER RESOURCE GROUP admin_group SET CPU_SOFT_PRIORITY 100;`,
-					`ALTER RESOURCE GROUP default_group SET CPU_HARD_QUOTA_LIMIT 1;`,
-					`ALTER RESOURCE GROUP default_group SET CPU_SOFT_PRIORITY 100;`,
-					`ALTER RESOURCE GROUP system_group SET CPU_HARD_QUOTA_LIMIT 1;`,
-					`ALTER RESOURCE GROUP system_group SET CPU_SOFT_PRIORITY 100;`)
+					`ALTER RESOURCE GROUP admin_group SET CPU_MAX_PERCENT 1;`,
+					`ALTER RESOURCE GROUP admin_group SET CPU_WEIGHT 100;`,
+					`ALTER RESOURCE GROUP default_group SET CPU_MAX_PERCENT 1;`,
+					`ALTER RESOURCE GROUP default_group SET CPU_WEIGHT 100;`,
+					`ALTER RESOURCE GROUP system_group SET CPU_MAX_PERCENT 1;`,
+					`ALTER RESOURCE GROUP system_group SET CPU_WEIGHT 100;`)
 
 			}
 		})

--- a/meta/builtin/queries_globals.go
+++ b/meta/builtin/queries_globals.go
@@ -231,15 +231,15 @@ type ResourceGroupBefore7 struct {
 }
 
 type ResourceGroupAtLeast7 struct {
-	ResourceGroup            // embedded common rg fields+methods
-	CpuHardQuotaLimit string `db:"cpu_hard_quota_limit"`
-	CpuSoftPriority   string `db:"cpu_soft_priority"`
+	ResourceGroup        // embedded common rg fields+methods
+	CpuMaxPercent string `db:"cpu_max_percent"`
+	CpuWeight     string `db:"cpu_weight"`
 }
 
 func GetResourceGroups[T ResourceGroupBefore7 | ResourceGroupAtLeast7](connectionPool *dbconn.DBConn) []T {
 	var query string
 
-	if (connectionPool.Version.IsGPDB() && connectionPool.Version.Before("7")) || connectionPool.Version.IsCBDB() {
+	if connectionPool.Version.IsGPDB() && connectionPool.Version.Before("7") {
 		before7SelectClause := ""
 		// This is when pg_dumpall was changed to use the actual values
 		if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("5.2.0")) || connectionPool.Version.IsCBDB() {
@@ -296,8 +296,8 @@ func GetResourceGroups[T ResourceGroupBefore7 | ResourceGroupAtLeast7](connectio
 				g.oid       AS oid,
 				g.rsgname   AS name,
 				t1.value    AS concurrency,
-				t2.value    AS cpu_hard_quota_limit,
-				t3.value    AS cpu_soft_priority,
+				t2.value    AS cpu_max_percent,
+				t3.value    AS cpu_weight,
 				t4.value    AS cpuset
 			FROM pg_resgroup g
 				JOIN pg_resgroupcapability t1 ON g.oid = t1.resgroupid AND t1.reslimittype = 1


### PR DESCRIPTION
The Greenplum upstream had renamed resgroup option names two times in gpdb7. The latest names are not updated in cbcopy.

The commits to rename option names are:
https://github.com/greenplum-db/gpdb-archive/commit/7a4c80d7e3dbab86c https://github.com/greenplum-db/gpdb-archive/commit/483adea86b50c1759

The affected name changes are:
cpu_rate_limit -> cpu_hard_quota_limit -> cpu_max_percent cpu_soft_priority -> cpu_weight



---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) as a reference.
* Sign the Contributor License Agreement as prompted for your first-time contribution (*One-time setup*).
* Learn the [code contribution](https://cloudberrydb.org/contribute/code) and [doc contribution](https://cloudberrydb.org/contribute/doc) guides for better collaboration.
* List your communications in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb-site/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
* Feel free to ask for the cloudberrydb team to help review and approve.
