### PR TITLE
feat(option): add --skip-existing flag (CLI & mutex validation only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,12 @@ cbcopy supports seven migration modes.
 - `--global-metadata-only` - Migrate global objects from the source database to the destination database.
 
 ### Data Loading Modes
-cbcopy supports two data loading modes.
+cbcopy supports three data loading modes; exactly one must be specified
+(except in `--metadata-only` / `--global-metadata-only` mode):
 
 - `--append` - Insert the migrated records into the table directly, regardless of the existing records.
 - `--truncate` - First, clear the existing records in the table, and then insert the migrated records into the table.
+- `--skip-existing` - Skip copying a table from the source database if a table with the same fully qualified name already exists in the destination database. Aligned with gpcopy's option of the same name. The existence check is by FQN only; column definitions are not compared. For partitioned tables the check is by root-table FQN, so the entire partition tree is skipped when the root exists.
 
 ### Object dependencies
 
@@ -351,6 +353,7 @@ Flags:
       --quiet                            Suppress non-warning, non-error log messages
       --schema strings                   The schema(s) to be copied, separated by commas, in the format database.schema
       --schema-mapping-file string       Schema mapping file, The line format is "source_dbname.source_schema,dest_dbname.dest_schema"
+      --skip-existing                    Skip copying a table if it already exists in the destination database
       --source-host string               The host of source cluster (default "127.0.0.1")
       --source-port int                  The port of source cluster (default 5432)
       --source-user string               The user of source cluster (default "gpadmin")

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -125,6 +125,7 @@ func (app *Application) SetFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(option.SOURCE_HOST, "127.0.0.1", "The host of source cluster")
 	flagSet.Int(option.SOURCE_PORT, 5432, "The port of source cluster")
 	flagSet.String(option.SOURCE_USER, "gpadmin", "The user of source cluster")
+	flagSet.Bool(option.SKIP_EXISTING, false, "Skip copying a table if it already exists in the destination database")
 	flagSet.Bool(option.TRUNCATE, false, "Truncate destination table if it exists prior to copying data")
 	flagSet.StringSlice(option.SCHEMA, []string{}, "The schema(s) to be copied, separated by commas, in the format database.schema")
 	flagSet.StringSlice(option.DEST_SCHEMA, []string{}, "The schema(s) in destination database to copy to, separated by commas")

--- a/copy/copy_validator.go
+++ b/copy/copy_validator.go
@@ -260,13 +260,28 @@ func (v *ModeValidator) validateCopyMode() error {
 	return nil
 }
 
-// validateTableMode validates the table mode flags
+// validateTableMode validates the table mode flags. Exactly one of
+// --truncate, --append, --skip-existing must be set, unless the copy is in
+// --metadata-only / --global-metadata-only mode (where table-data handling
+// is irrelevant).
 func (v *ModeValidator) validateTableMode() error {
-	if !utils.MustGetFlagBool(option.METADATA_ONLY) &&
-		!utils.MustGetFlagBool(option.GLOBAL_METADATA_ONLY) &&
-		!utils.MustGetFlagBool(option.TRUNCATE) &&
-		!utils.MustGetFlagBool(option.APPEND) {
-		return &ValidationError{"One and only one of the following flags must be specified: truncate, append"}
+	if utils.MustGetFlagBool(option.METADATA_ONLY) ||
+		utils.MustGetFlagBool(option.GLOBAL_METADATA_ONLY) {
+		return nil
+	}
+	flags := []bool{
+		utils.MustGetFlagBool(option.TRUNCATE),
+		utils.MustGetFlagBool(option.APPEND),
+		utils.MustGetFlagBool(option.SKIP_EXISTING),
+	}
+	n := 0
+	for _, f := range flags {
+		if f {
+			n++
+		}
+	}
+	if n != 1 {
+		return &ValidationError{"One and only one of the following flags must be specified: --truncate, --append, --skip-existing"}
 	}
 	return nil
 }

--- a/copy/copy_validator_test.go
+++ b/copy/copy_validator_test.go
@@ -1,0 +1,80 @@
+package copy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudberry-contrib/cbcopy/option"
+	"github.com/cloudberry-contrib/cbcopy/utils"
+	"github.com/spf13/pflag"
+)
+
+func setupTableModeFlags(truncate, appendFlag, skipExisting, metadataOnly, globalMetadataOnly bool) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool(option.TRUNCATE, false, "")
+	flags.Bool(option.APPEND, false, "")
+	flags.Bool(option.SKIP_EXISTING, false, "")
+	flags.Bool(option.METADATA_ONLY, false, "")
+	flags.Bool(option.GLOBAL_METADATA_ONLY, false, "")
+
+	boolStr := func(b bool) string {
+		if b {
+			return "true"
+		}
+		return "false"
+	}
+	_ = flags.Set(option.TRUNCATE, boolStr(truncate))
+	_ = flags.Set(option.APPEND, boolStr(appendFlag))
+	_ = flags.Set(option.SKIP_EXISTING, boolStr(skipExisting))
+	_ = flags.Set(option.METADATA_ONLY, boolStr(metadataOnly))
+	_ = flags.Set(option.GLOBAL_METADATA_ONLY, boolStr(globalMetadataOnly))
+
+	utils.SetCmdFlags(flags)
+	return flags
+}
+
+func TestValidateTableMode(t *testing.T) {
+	const mutexMsg = "One and only one of the following flags must be specified: --truncate, --append, --skip-existing"
+
+	cases := []struct {
+		name                                                                        string
+		truncate, appendFlag, skipExisting, metadataOnly, globalMetadataOnly        bool
+		wantErrSubstr                                                               string
+	}{
+		{"truncate only", true, false, false, false, false, ""},
+		{"append only", false, true, false, false, false, ""},
+		{"skip-existing only", false, false, true, false, false, ""},
+
+		{"truncate + append", true, true, false, false, false, mutexMsg},
+		{"truncate + skip-existing", true, false, true, false, false, mutexMsg},
+		{"append + skip-existing", false, true, true, false, false, mutexMsg},
+		{"all three", true, true, true, false, false, mutexMsg},
+		{"none", false, false, false, false, false, mutexMsg},
+
+		{"metadata-only bypass even with none", false, false, false, true, false, ""},
+		{"global-metadata-only bypass even with none", false, false, false, false, true, ""},
+		{"metadata-only bypass with conflicting flags", true, true, true, true, false, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := setupTableModeFlags(tc.truncate, tc.appendFlag, tc.skipExisting, tc.metadataOnly, tc.globalMetadataOnly)
+			v := NewModeValidator(flags)
+
+			err := v.validateTableMode()
+
+			if tc.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErrSubstr, err.Error())
+			}
+		})
+	}
+}

--- a/option/option.go
+++ b/option/option.go
@@ -40,6 +40,7 @@ const (
 	SOURCE_HOST             = "source-host"
 	SOURCE_PORT             = "source-port"
 	SOURCE_USER             = "source-user"
+	SKIP_EXISTING           = "skip-existing"
 	TRUNCATE                = "truncate"
 	VALIDATE                = "validate"
 	SCHEMA                  = "schema"
@@ -73,8 +74,9 @@ const (
 )
 
 const (
-	TableModeTruncate = "truncate"
-	TableModeAppend   = "append"
+	TableModeTruncate     = "truncate"
+	TableModeAppend       = "append"
+	TableModeSkipExisting = "skip-existing"
 )
 
 type DbTable struct {
@@ -171,6 +173,9 @@ func NewOption(initialFlags *pflag.FlagSet) (*Option, error) {
 
 	if append, _ := initialFlags.GetBool(APPEND); append {
 		tableMode = TableModeAppend
+	}
+	if skipExisting, _ := initialFlags.GetBool(SKIP_EXISTING); skipExisting {
+		tableMode = TableModeSkipExisting
 	}
 
 	ownerMap, err := getOwnerMap(initialFlags)


### PR DESCRIPTION
Related to #17. **First of two PRs in this series**; the implementation work that actually makes `--skip-existing` skip anything lands in #31 (stacked on top of this one).

## Change logs

Introduce a new `--skip-existing` option, aligned with VMware/Broadcom gpcopy's option of the same name: when set, tables that already exist on the destination database are skipped (no DDL, no COPY, no owner/ACL changes). The existence check is by fully-qualified name; column definitions are not compared. For partitioned tables the check is by root-table FQN, so an entire partition tree is skipped when the root exists.

This PR is intentionally narrow and **only adds the CLI surface and the mutex validation**. The actual skip behavior (dest-inventory persistence, DDL pipeline filter, data-channel filter, summary/list-file output, and end-to-end tests) is wired up in #31. Splitting the work this way lets reviewers approve the CLI shape and naming independently of the implementation details.

Specifically this PR:

- Adds `--skip-existing` boolean flag and the `TableModeSkipExisting` enum value.
- Tightens `validateTableMode()` to enforce **exactly one** of `--truncate` / `--append` / `--skip-existing`. The previous error message already claimed "one and only one", but the check only enforced "at least one"; passing both `--truncate` and `--append` used to silently resolve to `--append`.
- Keeps the existing `--metadata-only` / `--global-metadata-only` bypass behavior — those modes don't care about table-data handling.
- Adds unit tests covering all 8 combinations of the three flags plus the two bypass modes (11 cases total).
- Updates README's "Data Loading Modes" section and the Flags table.

No runtime behavior change yet: nothing reads `TableModeSkipExisting` in this PR, so existing `--truncate` / `--append` flows are unchanged. #31 picks up that wiring.

## Contributor's checklist

- [x] Title and commit message follow the Conventional Commits style already used by the repo.
- [x] CLA signed.