### PR TITLE
feat(skip-existing): wire up the actual skip behavior, end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,12 @@ cbcopy supports seven migration modes.
 - `--global-metadata-only` - Migrate global objects from the source database to the destination database.
 
 ### Data Loading Modes
-cbcopy supports two data loading modes.
+cbcopy supports three data loading modes; exactly one must be specified
+(except in `--metadata-only` / `--global-metadata-only` mode):
 
 - `--append` - Insert the migrated records into the table directly, regardless of the existing records.
 - `--truncate` - First, clear the existing records in the table, and then insert the migrated records into the table.
+- `--skip-existing` - Skip copying a table from the source database if a table with the same fully qualified name already exists in the destination database. Aligned with gpcopy's option of the same name. The existence check is by FQN only; column definitions are not compared. For partitioned tables the check is by root-table FQN, so the entire partition tree is skipped when the root exists.
 
 ### Object dependencies
 
@@ -351,6 +353,7 @@ Flags:
       --quiet                            Suppress non-warning, non-error log messages
       --schema strings                   The schema(s) to be copied, separated by commas, in the format database.schema
       --schema-mapping-file string       Schema mapping file, The line format is "source_dbname.source_schema,dest_dbname.dest_schema"
+      --skip-existing                    Skip copying a table if it already exists in the destination database
       --source-host string               The host of source cluster (default "127.0.0.1")
       --source-port int                  The port of source cluster (default 5432)
       --source-user string               The user of source cluster (default "gpadmin")

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -125,6 +125,7 @@ func (app *Application) SetFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(option.SOURCE_HOST, "127.0.0.1", "The host of source cluster")
 	flagSet.Int(option.SOURCE_PORT, 5432, "The port of source cluster")
 	flagSet.String(option.SOURCE_USER, "gpadmin", "The user of source cluster")
+	flagSet.Bool(option.SKIP_EXISTING, false, "Skip copying a table if it already exists in the destination database")
 	flagSet.Bool(option.TRUNCATE, false, "Truncate destination table if it exists prior to copying data")
 	flagSet.StringSlice(option.SCHEMA, []string{}, "The schema(s) to be copied, separated by commas, in the format database.schema")
 	flagSet.StringSlice(option.DEST_SCHEMA, []string{}, "The schema(s) in destination database to copy to, separated by commas")

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apache/cloudberry-go-libs/gplog"
 	"github.com/cloudberry-contrib/cbcopy/internal/dbconn"
+	"github.com/cloudberry-contrib/cbcopy/meta/builtin"
 	"github.com/cloudberry-contrib/cbcopy/option"
 	"github.com/cloudberry-contrib/cbcopy/utils"
 	"github.com/spf13/cobra"
@@ -185,6 +186,7 @@ func (app *Application) doSetup() {
 	var err error
 	config, err = option.NewOption(utils.CmdFlags)
 	gplog.FatalOnError(err)
+	builtin.SetOption(config)
 
 	gplog.Info("Establishing 1 source db management connection(s)...")
 	app.srcManageConn = app.initializeConnectionPool("postgres",

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -339,6 +339,14 @@ func (app *Application) doCopy() {
 		i++
 	}
 
+	// --skip-existing: emit a single summary line and persist the list of
+	// bypassed tables once all databases have been processed. No-ops when
+	// the option wasn't used or nothing was skipped.
+	builtin.LogSkipExistingSummary()
+	if err := builtin.WriteSkipExistingList(app.timestamp); err != nil {
+		gplog.Warn("[skip-existing] failed to write skip_existing.list: %v", err)
+	}
+
 	gplog.Info("Total elapsed time: %v", time.Since(start))
 }
 

--- a/copy/copy_metadata.go
+++ b/copy/copy_metadata.go
@@ -3,6 +3,7 @@ package copy
 import (
 	"github.com/cloudberry-contrib/cbcopy/internal/dbconn"
 	"github.com/cloudberry-contrib/cbcopy/meta"
+	"github.com/cloudberry-contrib/cbcopy/meta/builtin"
 	"github.com/cloudberry-contrib/cbcopy/option"
 	"github.com/cloudberry-contrib/cbcopy/utils"
 )
@@ -53,6 +54,17 @@ func (m *MetadataManager) Close() {
 func (m *MetadataManager) MigrateMetadata(srcTables, destTables, nonPhysicalRels []option.Table) (chan option.TablePair, utils.ProgressBar) {
 	var pgd utils.ProgressBar
 
+	// --skip-existing: drop already-present-on-destination tables from the
+	// src/dest parallel arrays before the data channel is sized or filled.
+	// This covers CopyModeTable + --dest-table mode, where MigrateMetadata
+	// short-circuits through fillTablePairChan and the DDL pipeline's filter
+	// in RetrieveAndProcessTables never sees these tables. The DDL filter
+	// covers Full / Db / Schema / Table-without-dest-table modes; this one
+	// is the missing piece for the explicit-mapping path.
+	if utils.MustGetFlagBool(option.SKIP_EXISTING) {
+		srcTables, destTables = filterTablePairsByDestExisting(m.destConn.DBName, srcTables, destTables)
+	}
+
 	mode := config.GetCopyMode()
 	tablec := make(chan option.TablePair, len(destTables))
 
@@ -101,6 +113,28 @@ func (m *MetadataManager) Wait() {
 	}
 
 	<-m.donec
+}
+
+// filterTablePairsByDestExisting drops, from the parallel src/dest table
+// arrays, any entry whose destination side is already present on the
+// destination database. This covers the CopyModeTable + --dest-table flow
+// where MigrateMetadata bypasses DDL extraction entirely. Each filtered
+// pair is recorded via builtin.RecordPairSkip for the summary writer.
+func filterTablePairsByDestExisting(destDbName string, src, dst []option.Table) ([]option.Table, []option.Table) {
+	if len(src) == 0 {
+		return src, dst
+	}
+	keptSrc := make([]option.Table, 0, len(src))
+	keptDst := make([]option.Table, 0, len(dst))
+	for i := range src {
+		if config.IsDestTableExisting(destDbName, dst[i].Schema, dst[i].Name) {
+			builtin.RecordPairSkip(src[i].Schema, src[i].Name, dst[i].Schema, dst[i].Name)
+			continue
+		}
+		keptSrc = append(keptSrc, src[i])
+		keptDst = append(keptDst, dst[i])
+	}
+	return keptSrc, keptDst
 }
 
 // fillTablePairChan fills the table pair channel with source and destination tables

--- a/copy/copy_metadata.go
+++ b/copy/copy_metadata.go
@@ -62,7 +62,7 @@ func (m *MetadataManager) MigrateMetadata(srcTables, destTables, nonPhysicalRels
 	// covers Full / Db / Schema / Table-without-dest-table modes; this one
 	// is the missing piece for the explicit-mapping path.
 	if utils.MustGetFlagBool(option.SKIP_EXISTING) {
-		srcTables, destTables = filterTablePairsByDestExisting(m.destConn.DBName, srcTables, destTables)
+		srcTables, destTables = filterTablePairsByDestExisting(m.srcConn.DBName, m.destConn.DBName, srcTables, destTables)
 	}
 
 	mode := config.GetCopyMode()
@@ -120,7 +120,7 @@ func (m *MetadataManager) Wait() {
 // destination database. This covers the CopyModeTable + --dest-table flow
 // where MigrateMetadata bypasses DDL extraction entirely. Each filtered
 // pair is recorded via builtin.RecordPairSkip for the summary writer.
-func filterTablePairsByDestExisting(destDbName string, src, dst []option.Table) ([]option.Table, []option.Table) {
+func filterTablePairsByDestExisting(srcDbName, destDbName string, src, dst []option.Table) ([]option.Table, []option.Table) {
 	if len(src) == 0 {
 		return src, dst
 	}
@@ -128,7 +128,10 @@ func filterTablePairsByDestExisting(destDbName string, src, dst []option.Table) 
 	keptDst := make([]option.Table, 0, len(dst))
 	for i := range src {
 		if config.IsDestTableExisting(destDbName, dst[i].Schema, dst[i].Name) {
-			builtin.RecordPairSkip(src[i].Schema, src[i].Name, dst[i].Schema, dst[i].Name)
+			builtin.RecordPairSkip(
+				srcDbName, src[i].Schema, src[i].Name,
+				destDbName, dst[i].Schema, dst[i].Name,
+			)
 			continue
 		}
 		keptSrc = append(keptSrc, src[i])

--- a/copy/copy_metadata_test.go
+++ b/copy/copy_metadata_test.go
@@ -1,0 +1,137 @@
+package copy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cloudberry-contrib/cbcopy/meta/builtin"
+	"github.com/cloudberry-contrib/cbcopy/option"
+	"github.com/cloudberry-contrib/cbcopy/utils"
+	"github.com/spf13/pflag"
+)
+
+// setupTablePairFilterFixtures installs the global config that
+// filterTablePairsByDestExisting reads from. The destination inventory is
+// seeded via Option.MarkDestTables so the helper exercises the same path
+// production uses.
+func setupTablePairFilterFixtures(t *testing.T, destDb string, present []string) {
+	t.Helper()
+
+	fs := pflag.NewFlagSet("table-pair-filter-test", pflag.ContinueOnError)
+	fs.StringSlice(option.DBNAME, []string{}, "")
+	fs.StringSlice(option.DEST_DBNAME, []string{}, "")
+	fs.StringSlice(option.EXCLUDE_TABLE, []string{}, "")
+	fs.String(option.EXCLUDE_TABLE_FILE, "", "")
+	fs.StringSlice(option.INCLUDE_TABLE, []string{}, "")
+	fs.String(option.INCLUDE_TABLE_FILE, "", "")
+	fs.StringSlice(option.DEST_TABLE, []string{}, "")
+	fs.String(option.DEST_TABLE_FILE, "", "")
+	fs.Bool(option.APPEND, false, "")
+	fs.Bool(option.SKIP_EXISTING, true, "")
+	fs.StringSlice(option.SCHEMA, []string{}, "")
+	fs.StringSlice(option.DEST_SCHEMA, []string{}, "")
+	fs.String(option.SCHEMA_MAPPING_FILE, "", "")
+	fs.String(option.OWNER_MAPPING_FILE, "", "")
+	fs.String(option.DEST_TABLESPACE, "", "")
+	fs.String(option.TABLESPACE_MAPPING_FILE, "", "")
+	fs.String(option.CONNECTION_MODE, "push", "")
+	utils.SetCmdFlags(fs)
+
+	o, err := option.NewOption(fs)
+	if err != nil {
+		t.Fatalf("NewOption: %v", err)
+	}
+	userTables := make(map[string]option.TableStatistics, len(present))
+	for _, fqn := range present {
+		userTables[fqn] = option.TableStatistics{}
+	}
+	o.MarkDestTables(destDb, userTables, map[string]bool{})
+	config = o
+
+	builtin.ResetSkipExistingState()
+}
+
+func TestFilterTablePairs_NoneOnDest_AllKept(t *testing.T) {
+	setupTablePairFilterFixtures(t, "dst", nil)
+
+	src := []option.Table{
+		{Schema: "src_s", Name: "t1"},
+		{Schema: "src_s", Name: "t2"},
+	}
+	dst := []option.Table{
+		{Schema: "dst_s", Name: "t1"},
+		{Schema: "dst_s", Name: "t2"},
+	}
+	keptSrc, keptDst := filterTablePairsByDestExisting("dst", src, dst)
+	if !reflect.DeepEqual(keptSrc, src) || !reflect.DeepEqual(keptDst, dst) {
+		t.Fatalf("expected all pairs kept, got src=%v dst=%v", keptSrc, keptDst)
+	}
+	if builtin.NumSkipExisting() != 0 {
+		t.Fatalf("expected 0 skips, got %d", builtin.NumSkipExisting())
+	}
+}
+
+func TestFilterTablePairs_SomeOnDest_FilteredAndRecorded(t *testing.T) {
+	// dst_s.t1 exists on dest; dst_s.t2 does not.
+	setupTablePairFilterFixtures(t, "dst", []string{"dst_s.t1"})
+
+	src := []option.Table{
+		{Schema: "src_s", Name: "src_t1"},
+		{Schema: "src_s", Name: "src_t2"},
+	}
+	dst := []option.Table{
+		{Schema: "dst_s", Name: "t1"},
+		{Schema: "dst_s", Name: "t2"},
+	}
+	keptSrc, keptDst := filterTablePairsByDestExisting("dst", src, dst)
+
+	if len(keptSrc) != 1 || keptSrc[0].Name != "src_t2" {
+		t.Fatalf("expected only src_t2 kept, got %v", keptSrc)
+	}
+	if len(keptDst) != 1 || keptDst[0].Name != "t2" {
+		t.Fatalf("expected only dst_s.t2 kept, got %v", keptDst)
+	}
+	if builtin.NumSkipExisting() != 1 {
+		t.Fatalf("expected 1 recorded skip, got %d", builtin.NumSkipExisting())
+	}
+	rec := builtin.SkipExistingTables()[0]
+	if rec.SourceSchema != "src_s" || rec.SourceName != "src_t1" ||
+		rec.DestSchema != "dst_s" || rec.DestName != "t1" {
+		t.Fatalf("unexpected skip record: %+v", rec)
+	}
+	if rec.Reason != builtin.SkipReasonExists {
+		t.Fatalf("expected SkipReasonExists, got %v", rec.Reason)
+	}
+}
+
+func TestFilterTablePairs_AllOnDest_NoneKept(t *testing.T) {
+	setupTablePairFilterFixtures(t, "dst", []string{"dst_s.t1", "dst_s.t2"})
+
+	src := []option.Table{
+		{Schema: "src_s", Name: "t1"},
+		{Schema: "src_s", Name: "t2"},
+	}
+	dst := []option.Table{
+		{Schema: "dst_s", Name: "t1"},
+		{Schema: "dst_s", Name: "t2"},
+	}
+	keptSrc, keptDst := filterTablePairsByDestExisting("dst", src, dst)
+	if len(keptSrc) != 0 || len(keptDst) != 0 {
+		t.Fatalf("expected no pairs kept, got src=%v dst=%v", keptSrc, keptDst)
+	}
+	if builtin.NumSkipExisting() != 2 {
+		t.Fatalf("expected 2 recorded skips, got %d", builtin.NumSkipExisting())
+	}
+}
+
+func TestFilterTablePairs_EmptyInput_Passthrough(t *testing.T) {
+	setupTablePairFilterFixtures(t, "dst", []string{"dst_s.anything"})
+
+	keptSrc, keptDst := filterTablePairsByDestExisting("dst", nil, nil)
+	if keptSrc != nil || keptDst != nil {
+		t.Fatalf("expected nil passthrough on empty input, got src=%v dst=%v", keptSrc, keptDst)
+	}
+	if builtin.NumSkipExisting() != 0 {
+		t.Fatalf("expected 0 skips, got %d", builtin.NumSkipExisting())
+	}
+}

--- a/copy/copy_metadata_test.go
+++ b/copy/copy_metadata_test.go
@@ -62,7 +62,7 @@ func TestFilterTablePairs_NoneOnDest_AllKept(t *testing.T) {
 		{Schema: "dst_s", Name: "t1"},
 		{Schema: "dst_s", Name: "t2"},
 	}
-	keptSrc, keptDst := filterTablePairsByDestExisting("dst", src, dst)
+	keptSrc, keptDst := filterTablePairsByDestExisting("src", "dst", src, dst)
 	if !reflect.DeepEqual(keptSrc, src) || !reflect.DeepEqual(keptDst, dst) {
 		t.Fatalf("expected all pairs kept, got src=%v dst=%v", keptSrc, keptDst)
 	}
@@ -83,7 +83,7 @@ func TestFilterTablePairs_SomeOnDest_FilteredAndRecorded(t *testing.T) {
 		{Schema: "dst_s", Name: "t1"},
 		{Schema: "dst_s", Name: "t2"},
 	}
-	keptSrc, keptDst := filterTablePairsByDestExisting("dst", src, dst)
+	keptSrc, keptDst := filterTablePairsByDestExisting("src", "dst", src, dst)
 
 	if len(keptSrc) != 1 || keptSrc[0].Name != "src_t2" {
 		t.Fatalf("expected only src_t2 kept, got %v", keptSrc)
@@ -95,8 +95,8 @@ func TestFilterTablePairs_SomeOnDest_FilteredAndRecorded(t *testing.T) {
 		t.Fatalf("expected 1 recorded skip, got %d", builtin.NumSkipExisting())
 	}
 	rec := builtin.SkipExistingTables()[0]
-	if rec.SourceSchema != "src_s" || rec.SourceName != "src_t1" ||
-		rec.DestSchema != "dst_s" || rec.DestName != "t1" {
+	if rec.SourceDbName != "src" || rec.SourceSchema != "src_s" || rec.SourceName != "src_t1" ||
+		rec.DestDbName != "dst" || rec.DestSchema != "dst_s" || rec.DestName != "t1" {
 		t.Fatalf("unexpected skip record: %+v", rec)
 	}
 	if rec.Reason != builtin.SkipReasonExists {
@@ -115,7 +115,7 @@ func TestFilterTablePairs_AllOnDest_NoneKept(t *testing.T) {
 		{Schema: "dst_s", Name: "t1"},
 		{Schema: "dst_s", Name: "t2"},
 	}
-	keptSrc, keptDst := filterTablePairsByDestExisting("dst", src, dst)
+	keptSrc, keptDst := filterTablePairsByDestExisting("src", "dst", src, dst)
 	if len(keptSrc) != 0 || len(keptDst) != 0 {
 		t.Fatalf("expected no pairs kept, got src=%v dst=%v", keptSrc, keptDst)
 	}
@@ -127,7 +127,7 @@ func TestFilterTablePairs_AllOnDest_NoneKept(t *testing.T) {
 func TestFilterTablePairs_EmptyInput_Passthrough(t *testing.T) {
 	setupTablePairFilterFixtures(t, "dst", []string{"dst_s.anything"})
 
-	keptSrc, keptDst := filterTablePairsByDestExisting("dst", nil, nil)
+	keptSrc, keptDst := filterTablePairsByDestExisting("src", "dst", nil, nil)
 	if keptSrc != nil || keptDst != nil {
 		t.Fatalf("expected nil passthrough on empty input, got src=%v dst=%v", keptSrc, keptDst)
 	}

--- a/copy/copy_validator.go
+++ b/copy/copy_validator.go
@@ -260,13 +260,28 @@ func (v *ModeValidator) validateCopyMode() error {
 	return nil
 }
 
-// validateTableMode validates the table mode flags
+// validateTableMode validates the table mode flags. Exactly one of
+// --truncate, --append, --skip-existing must be set, unless the copy is in
+// --metadata-only / --global-metadata-only mode (where table-data handling
+// is irrelevant).
 func (v *ModeValidator) validateTableMode() error {
-	if !utils.MustGetFlagBool(option.METADATA_ONLY) &&
-		!utils.MustGetFlagBool(option.GLOBAL_METADATA_ONLY) &&
-		!utils.MustGetFlagBool(option.TRUNCATE) &&
-		!utils.MustGetFlagBool(option.APPEND) {
-		return &ValidationError{"One and only one of the following flags must be specified: truncate, append"}
+	if utils.MustGetFlagBool(option.METADATA_ONLY) ||
+		utils.MustGetFlagBool(option.GLOBAL_METADATA_ONLY) {
+		return nil
+	}
+	flags := []bool{
+		utils.MustGetFlagBool(option.TRUNCATE),
+		utils.MustGetFlagBool(option.APPEND),
+		utils.MustGetFlagBool(option.SKIP_EXISTING),
+	}
+	n := 0
+	for _, f := range flags {
+		if f {
+			n++
+		}
+	}
+	if n != 1 {
+		return &ValidationError{"One and only one of the following flags must be specified: --truncate, --append, --skip-existing"}
 	}
 	return nil
 }

--- a/copy/copy_validator_test.go
+++ b/copy/copy_validator_test.go
@@ -1,0 +1,80 @@
+package copy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudberry-contrib/cbcopy/option"
+	"github.com/cloudberry-contrib/cbcopy/utils"
+	"github.com/spf13/pflag"
+)
+
+func setupTableModeFlags(truncate, appendFlag, skipExisting, metadataOnly, globalMetadataOnly bool) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool(option.TRUNCATE, false, "")
+	flags.Bool(option.APPEND, false, "")
+	flags.Bool(option.SKIP_EXISTING, false, "")
+	flags.Bool(option.METADATA_ONLY, false, "")
+	flags.Bool(option.GLOBAL_METADATA_ONLY, false, "")
+
+	boolStr := func(b bool) string {
+		if b {
+			return "true"
+		}
+		return "false"
+	}
+	_ = flags.Set(option.TRUNCATE, boolStr(truncate))
+	_ = flags.Set(option.APPEND, boolStr(appendFlag))
+	_ = flags.Set(option.SKIP_EXISTING, boolStr(skipExisting))
+	_ = flags.Set(option.METADATA_ONLY, boolStr(metadataOnly))
+	_ = flags.Set(option.GLOBAL_METADATA_ONLY, boolStr(globalMetadataOnly))
+
+	utils.SetCmdFlags(flags)
+	return flags
+}
+
+func TestValidateTableMode(t *testing.T) {
+	const mutexMsg = "One and only one of the following flags must be specified: --truncate, --append, --skip-existing"
+
+	cases := []struct {
+		name                                                                        string
+		truncate, appendFlag, skipExisting, metadataOnly, globalMetadataOnly        bool
+		wantErrSubstr                                                               string
+	}{
+		{"truncate only", true, false, false, false, false, ""},
+		{"append only", false, true, false, false, false, ""},
+		{"skip-existing only", false, false, true, false, false, ""},
+
+		{"truncate + append", true, true, false, false, false, mutexMsg},
+		{"truncate + skip-existing", true, false, true, false, false, mutexMsg},
+		{"append + skip-existing", false, true, true, false, false, mutexMsg},
+		{"all three", true, true, true, false, false, mutexMsg},
+		{"none", false, false, false, false, false, mutexMsg},
+
+		{"metadata-only bypass even with none", false, false, false, true, false, ""},
+		{"global-metadata-only bypass even with none", false, false, false, false, true, ""},
+		{"metadata-only bypass with conflicting flags", true, true, true, true, false, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := setupTableModeFlags(tc.truncate, tc.appendFlag, tc.skipExisting, tc.metadataOnly, tc.globalMetadataOnly)
+			v := NewModeValidator(flags)
+
+			err := v.validateTableMode()
+
+			if tc.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErrSubstr, err.Error())
+			}
+		})
+	}
+}

--- a/end_to_end/skip_existing_test.go
+++ b/end_to_end/skip_existing_test.go
@@ -1,0 +1,103 @@
+package end_to_end_test
+
+import (
+	"strconv"
+
+	"github.com/cloudberry-contrib/cbcopy/internal/testhelper"
+	"github.com/cloudberry-contrib/cbcopy/testutils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("--skip-existing migration tests", func() {
+	BeforeEach(func() {
+		end_to_end_setup()
+	})
+	AfterEach(func() {
+		end_to_end_teardown()
+	})
+
+	It("skips a regular table that already exists on the destination", func() {
+		srcTestConn := testutils.SetupTestDbConn("source_db")
+		destTestConn := testutils.SetupTestDbConn("target_db")
+		defer func() {
+			testhelper.AssertQueryRuns(srcTestConn, "DROP TABLE IF EXISTS public.se_keep")
+			testhelper.AssertQueryRuns(srcTestConn, "DROP TABLE IF EXISTS public.se_copy")
+			testhelper.AssertQueryRuns(destTestConn, "DROP TABLE IF EXISTS public.se_keep")
+			testhelper.AssertQueryRuns(destTestConn, "DROP TABLE IF EXISTS public.se_copy")
+			srcTestConn.Close()
+			destTestConn.Close()
+		}()
+
+		// Source: two tables, each with 100 rows.
+		testhelper.AssertQueryRuns(srcTestConn, "CREATE TABLE public.se_keep (i int)")
+		testhelper.AssertQueryRuns(srcTestConn, "INSERT INTO public.se_keep SELECT generate_series(1,100)")
+		testhelper.AssertQueryRuns(srcTestConn, "CREATE TABLE public.se_copy (i int)")
+		testhelper.AssertQueryRuns(srcTestConn, "INSERT INTO public.se_copy SELECT generate_series(1,100)")
+
+		// Destination: only se_keep is pre-populated, with DIFFERENT contents
+		// (5 rows). After --skip-existing, those 5 rows must remain untouched
+		// and se_copy must be created with the source's 100 rows.
+		testhelper.AssertQueryRuns(destTestConn, "CREATE TABLE public.se_keep (i int)")
+		testhelper.AssertQueryRuns(destTestConn, "INSERT INTO public.se_keep SELECT generate_series(1,5)")
+
+		cbcopy(cbcopyPath,
+			"--source-host", sourceConn.Host,
+			"--source-port", strconv.Itoa(sourceConn.Port),
+			"--source-user", sourceConn.User,
+			"--dest-host", destConn.Host,
+			"--dest-port", strconv.Itoa(destConn.Port),
+			"--dest-user", destConn.User,
+			"--dbname", "source_db",
+			"--dest-dbname", "target_db",
+			"--skip-existing")
+
+		// se_keep should be untouched (still 5 rows), se_copy should be the
+		// freshly copied 100 rows.
+		assertDataRestored(destTestConn, map[string]int{
+			"public.se_keep": 5,
+			"public.se_copy": 100,
+		})
+	})
+
+	It("skips an entire partition tree when the root exists on the destination", func() {
+		srcTestConn := testutils.SetupTestDbConn("source_db")
+		destTestConn := testutils.SetupTestDbConn("target_db")
+		defer func() {
+			testhelper.AssertQueryRuns(srcTestConn, "DROP TABLE IF EXISTS public.se_part CASCADE")
+			testhelper.AssertQueryRuns(destTestConn, "DROP TABLE IF EXISTS public.se_part CASCADE")
+			srcTestConn.Close()
+			destTestConn.Close()
+		}()
+
+		// Source: range-partitioned table with two leaves, 50 rows each.
+		testhelper.AssertQueryRuns(srcTestConn, `
+			CREATE TABLE public.se_part (i int) PARTITION BY RANGE(i)
+			(PARTITION p1 START (1) END (51), PARTITION p2 START (51) END (101))
+		`)
+		testhelper.AssertQueryRuns(srcTestConn, "INSERT INTO public.se_part SELECT generate_series(1,100)")
+
+		// Destination: same root structure pre-created, leaves empty.
+		// --skip-existing should leave it completely alone.
+		testhelper.AssertQueryRuns(destTestConn, `
+			CREATE TABLE public.se_part (i int) PARTITION BY RANGE(i)
+			(PARTITION p1 START (1) END (51), PARTITION p2 START (51) END (101))
+		`)
+
+		cbcopy(cbcopyPath,
+			"--source-host", sourceConn.Host,
+			"--source-port", strconv.Itoa(sourceConn.Port),
+			"--source-user", sourceConn.User,
+			"--dest-host", destConn.Host,
+			"--dest-port", strconv.Itoa(destConn.Port),
+			"--dest-user", destConn.User,
+			"--dbname", "source_db",
+			"--dest-dbname", "target_db",
+			"--skip-existing")
+
+		// Root existed on dest -> entire tree skipped -> still 0 rows.
+		assertDataRestored(destTestConn, map[string]int{
+			"public.se_part": 0,
+		})
+	})
+})

--- a/meta/builtin/builtin.go
+++ b/meta/builtin/builtin.go
@@ -50,6 +50,7 @@ func (b *BuiltinMeta) Open(srcConn, destConn *dbconn.DBConn) {
 
 	srcDBVersion = srcConn.Version
 	destDBVersion = destConn.Version
+	destDbName = destConn.DBName
 
 	globalTOC = &toc.TOC{}
 	globalTOC.InitializeMetadataEntryMap()

--- a/meta/builtin/builtin.go
+++ b/meta/builtin/builtin.go
@@ -50,6 +50,7 @@ func (b *BuiltinMeta) Open(srcConn, destConn *dbconn.DBConn) {
 
 	srcDBVersion = srcConn.Version
 	destDBVersion = destConn.Version
+	srcDbName = srcConn.DBName
 	destDbName = destConn.DBName
 
 	globalTOC = &toc.TOC{}

--- a/meta/builtin/extract_helper.go
+++ b/meta/builtin/extract_helper.go
@@ -24,6 +24,12 @@ func RetrieveAndProcessTables(conn *dbconn.DBConn, includeTables []string) ([]Ta
 
 	tables := ConstructDefinitionsForTables(conn, tableRelations)
 
+	// --skip-existing: drop tables (and their entire partition trees, when
+	// the root exists on the destination) from the plan before metadata
+	// extraction sees them, so no DDL / ACL / owner / comment statements
+	// are generated for the skipped objects.
+	tables = FilterTablesByDestExisting(tables)
+
 	metadataTables, dataTables := SplitTablesByPartitionType(conn, tables, quotedIncludeRelations)
 	objectCounts["Tables"] = len(metadataTables)
 

--- a/meta/builtin/skip_existing.go
+++ b/meta/builtin/skip_existing.go
@@ -1,8 +1,13 @@
 package builtin
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
+	"github.com/apache/cloudberry-go-libs/operating"
 	"github.com/cloudberry-contrib/cbcopy/option"
 	"github.com/cloudberry-contrib/cbcopy/utils"
 	"github.com/apache/cloudberry-go-libs/gplog"
@@ -93,6 +98,101 @@ func RecordPairSkip(srcSchema, srcName, destSchema, destName string) {
 		DestName:     destName,
 		Reason:       SkipReasonExists,
 	})
+}
+
+// WriteSkipExistingList persists the full set of tables that were bypassed
+// because of --skip-existing into ~/gpAdminLogs/<timestamp>_skip_existing.list.
+// Layout: one tab-separated line per table —
+//
+//	<reason>	<source_schema>.<source_name>	<dest_schema>.<dest_name>
+//
+// The file is written once, after all databases have been processed.
+// Returns nil and writes nothing if no tables were skipped.
+func WriteSkipExistingList(timestamp string) error {
+	snapshot := SkipExistingTables()
+	if len(snapshot) == 0 {
+		return nil
+	}
+
+	homeDir, err := homeDirectory()
+	if err != nil {
+		return fmt.Errorf("resolve user home: %w", err)
+	}
+	logDir := filepath.Join(homeDir, "gpAdminLogs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", logDir, err)
+	}
+	path := filepath.Join(logDir, fmt.Sprintf("%s_skip_existing.list", timestamp))
+
+	var b strings.Builder
+	for _, s := range snapshot {
+		b.WriteString(s.Reason.String())
+		b.WriteByte('\t')
+		b.WriteString(s.SourceSchema)
+		b.WriteByte('.')
+		b.WriteString(s.SourceName)
+		b.WriteByte('\t')
+		b.WriteString(s.DestSchema)
+		b.WriteByte('.')
+		b.WriteString(s.DestName)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	gplog.Info("[skip-existing] wrote %d entries to %s", len(snapshot), path)
+	return nil
+}
+
+// LogSkipExistingSummary writes a single Info-level line summarizing how
+// many tables --skip-existing bypassed during this run. Intended to be
+// called once near the end of cbcopy execution; complements (does not
+// replace) the per-database summary line emitted by CopyManager.
+func LogSkipExistingSummary() {
+	snapshot := SkipExistingTables()
+	if len(snapshot) == 0 {
+		return
+	}
+
+	var (
+		existsN     int
+		rootExistsN int
+		halfBuiltN  int
+	)
+	for _, s := range snapshot {
+		switch s.Reason {
+		case SkipReasonExists:
+			existsN++
+		case SkipReasonRootExists:
+			rootExistsN++
+		case SkipReasonHalfBuiltLeaf:
+			halfBuiltN++
+		}
+	}
+	gplog.Info("[skip-existing] bypassed %d table(s): %d already-exist, %d partition-tree (root present), %d half-built leaf warnings",
+		len(snapshot), existsN, rootExistsN, halfBuiltN)
+}
+
+// String returns a short label suitable for the skip_existing.list file.
+func (r SkipReason) String() string {
+	switch r {
+	case SkipReasonExists:
+		return "exists"
+	case SkipReasonRootExists:
+		return "root_exists"
+	case SkipReasonHalfBuiltLeaf:
+		return "half_built_leaf"
+	default:
+		return "unknown"
+	}
+}
+
+func homeDirectory() (string, error) {
+	user, err := operating.System.CurrentUser()
+	if err != nil {
+		return "", err
+	}
+	return user.HomeDir, nil
 }
 
 // FilterTablesByDestExisting removes tables that already exist on the

--- a/meta/builtin/skip_existing.go
+++ b/meta/builtin/skip_existing.go
@@ -79,6 +79,22 @@ func recordSkip(s SkippedTable) {
 	skipExistingTables = append(skipExistingTables, s)
 }
 
+// RecordPairSkip is the cross-package entry point used by the data-channel
+// filter (CopyModeTable + --dest-table flow in copy/copy_metadata.go), which
+// has the source and destination FQNs already paired up and so doesn't need
+// the partition/inheritance reasoning that FilterTablesByDestExisting
+// performs. The reason is fixed to SkipReasonExists because the caller has
+// already established that the destination row is present.
+func RecordPairSkip(srcSchema, srcName, destSchema, destName string) {
+	recordSkip(SkippedTable{
+		SourceSchema: srcSchema,
+		SourceName:   srcName,
+		DestSchema:   destSchema,
+		DestName:     destName,
+		Reason:       SkipReasonExists,
+	})
+}
+
 // FilterTablesByDestExisting removes tables that already exist on the
 // destination from the input slice and returns the survivors. Existence is
 // queried on the *translated* destination-side FQN (so --schema-mapping is

--- a/meta/builtin/skip_existing.go
+++ b/meta/builtin/skip_existing.go
@@ -1,0 +1,236 @@
+package builtin
+
+import (
+	"sync"
+
+	"github.com/cloudberry-contrib/cbcopy/option"
+	"github.com/cloudberry-contrib/cbcopy/utils"
+	"github.com/apache/cloudberry-go-libs/gplog"
+)
+
+// SkipReason categorizes why FilterTablesByDestExisting elected to bypass a
+// given table. Recorded on each SkippedTable entry for downstream reporting.
+type SkipReason int
+
+const (
+	// SkipReasonExists: the table itself (non-partition, or a partition root)
+	// is already present on the destination.
+	SkipReasonExists SkipReason = iota
+
+	// SkipReasonRootExists: the table is a partition leaf or intermediate
+	// whose root is present on the destination, so the entire partition tree
+	// is skipped as a unit.
+	SkipReasonRootExists
+
+	// SkipReasonHalfBuiltLeaf: CB→CB declarative-partition path only. The
+	// partition root is *absent* from the destination but this specific leaf
+	// *is* present — a half-built state the user must resolve manually. We
+	// emit a WARN and keep the leaf in the plan so the existing pipeline's
+	// "already exists" swallow path handles the conflict during DDL execution.
+	// (On the GP6 path the single inline CREATE will hard-error before this
+	// state can be observed at filter time, so no warning is needed there.)
+	SkipReasonHalfBuiltLeaf
+)
+
+// SkippedTable records one decision made by the --skip-existing filter.
+// Both source-side and destination-side schema/name pairs are kept because
+// they may differ under --schema-mapping.
+type SkippedTable struct {
+	SourceSchema string
+	SourceName   string
+	DestSchema   string
+	DestName     string
+	Reason       SkipReason
+}
+
+var (
+	skipExistingMu     sync.Mutex
+	skipExistingTables []SkippedTable
+)
+
+// NumSkipExisting reports how many tables have been bypassed by
+// --skip-existing so far. Used by the summary printer.
+func NumSkipExisting() int {
+	skipExistingMu.Lock()
+	defer skipExistingMu.Unlock()
+	return len(skipExistingTables)
+}
+
+// SkipExistingTables returns a copy of the recorded skip entries. Used by
+// the list-file writer and the summary section.
+func SkipExistingTables() []SkippedTable {
+	skipExistingMu.Lock()
+	defer skipExistingMu.Unlock()
+	out := make([]SkippedTable, len(skipExistingTables))
+	copy(out, skipExistingTables)
+	return out
+}
+
+// ResetSkipExistingState clears the recorder. Test-only.
+func ResetSkipExistingState() {
+	skipExistingMu.Lock()
+	defer skipExistingMu.Unlock()
+	skipExistingTables = nil
+}
+
+func recordSkip(s SkippedTable) {
+	skipExistingMu.Lock()
+	defer skipExistingMu.Unlock()
+	skipExistingTables = append(skipExistingTables, s)
+}
+
+// FilterTablesByDestExisting removes tables that already exist on the
+// destination from the input slice and returns the survivors. Existence is
+// queried on the *translated* destination-side FQN (so --schema-mapping is
+// applied). For partition trees the root's existence is authoritative: if
+// the root exists on the destination, the entire tree is skipped; if the
+// root is absent, the children are kept — except for the CB→CB half-built
+// case (see SkipReasonHalfBuiltLeaf).
+//
+// No-op unless --skip-existing is set and runtimeOption has been installed.
+func FilterTablesByDestExisting(tables []Table) []Table {
+	if !utils.MustGetFlagBool(option.SKIP_EXISTING) {
+		return tables
+	}
+	if runtimeOption == nil {
+		gplog.Warn("[skip-existing] runtimeOption is nil; skipping filter (this indicates a wiring bug)")
+		return tables
+	}
+
+	// Index by src FQN so walkToRoot can navigate the inheritance chain.
+	byFQN := make(map[string]Table, len(tables))
+	for _, t := range tables {
+		byFQN[t.Schema+"."+t.Name] = t
+	}
+
+	// Pass 1: decide which roots are bypassed. A "root" is either an explicit
+	// partition root (level "p") or a non-partition regular table (level "").
+	rootSkip := make(map[string]bool) // src root FQN -> true if root exists on dest
+	for _, t := range tables {
+		level := t.PartitionLevelInfo.Level
+		if level != "p" && level != "" {
+			continue
+		}
+		destSchema, destName := runtimeOption.TranslateToDestFQN(t.Schema, t.Name)
+		if runtimeOption.IsDestTableExisting(destDbName, destSchema, destName) {
+			rootSkip[t.Schema+"."+t.Name] = true
+		}
+	}
+
+	// Pass 2: for each table, apply the root decision and handle the
+	// per-table edge cases (external-partition leaf suffix, half-built leaves).
+	kept := make([]Table, 0, len(tables))
+	for _, t := range tables {
+		srcFQN := t.Schema + "." + t.Name
+		level := t.PartitionLevelInfo.Level
+
+		switch level {
+		case "p", "":
+			if rootSkip[srcFQN] {
+				ds, dn := runtimeOption.TranslateToDestFQN(t.Schema, t.Name)
+				recordSkip(SkippedTable{
+					SourceSchema: t.Schema, SourceName: t.Name,
+					DestSchema: ds, DestName: dn,
+					Reason: SkipReasonExists,
+				})
+				continue
+			}
+		case "l", "i":
+			rootFQN := walkToRoot(t, byFQN)
+			if rootSkip[rootFQN] {
+				ds, dn := runtimeOption.TranslateToDestFQN(t.Schema, t.Name)
+				recordSkip(SkippedTable{
+					SourceSchema: t.Schema, SourceName: t.Name,
+					DestSchema: ds, DestName: dn,
+					Reason: SkipReasonRootExists,
+				})
+				continue
+			}
+			if level == "l" {
+				// GP6 external-partition leaves are emitted on the destination
+				// with an "_ext_part_" suffix (see AppendExtPartSuffix). When
+				// the existence query targets the suffixed name and hits, the
+				// leaf is treated like a regular skipped table (the root is
+				// absent, but this leaf already has a destination presence).
+				if t.IsExternal && srcDBVersion.IsGPDB() && srcDBVersion.Before("7") {
+					suffixed := AppendExtPartSuffix(t.Name)
+					ds, dn := runtimeOption.TranslateToDestFQN(t.Schema, suffixed)
+					if runtimeOption.IsDestTableExisting(destDbName, ds, dn) {
+						recordSkip(SkippedTable{
+							SourceSchema: t.Schema, SourceName: t.Name,
+							DestSchema: ds, DestName: dn,
+							Reason: SkipReasonExists,
+						})
+						continue
+					}
+				}
+				// CB→CB half-built check: root absent on dest, but the leaf
+				// itself is present. Warn loudly so the user can decide; keep
+				// the leaf in the plan because the GP6 single-CREATE path
+				// hard-errors and the CB→CB attach path will swallow the
+				// already-exists CREATE and attach the stale leaf onto a
+				// freshly created root — a footgun, but matches gpcopy.
+				if isCBDBFamilyPath() {
+					ds, dn := runtimeOption.TranslateToDestFQN(t.Schema, t.Name)
+					if runtimeOption.IsDestTableExisting(destDbName, ds, dn) {
+						gplog.Warn("[skip-existing] partition leaf %s.%s exists on destination but its root does not; existing leaf will be attached to a freshly created root and may diverge from the source. Inspect the destination cluster before relying on the result.",
+							ds, dn)
+						recordSkip(SkippedTable{
+							SourceSchema: t.Schema, SourceName: t.Name,
+							DestSchema: ds, DestName: dn,
+							Reason: SkipReasonHalfBuiltLeaf,
+						})
+						// Intentionally do not "continue" — the leaf stays in
+						// the plan so the existing DDL pipeline observes the
+						// conflict and handles it consistently with the
+						// non-skip-existing flow.
+					}
+				}
+			}
+		}
+		kept = append(kept, t)
+	}
+
+	if got := len(tables) - len(kept); got > 0 {
+		gplog.Info("[skip-existing] %d table(s) bypassed because they already exist on destination database %q.",
+			got, destDbName)
+	}
+
+	return kept
+}
+
+// walkToRoot follows Table.Inherits up the chain until it reaches a row
+// whose PartitionLevelInfo.Level is "p" or "" (non-partition / root), and
+// returns that row's "schema.name" FQN. For tables that aren't part of any
+// partition tree this trivially returns the table's own FQN.
+//
+// Bounded by maxDepth so a pathological catalog can never lock the filter.
+func walkToRoot(t Table, byFQN map[string]Table) string {
+	const maxDepth = 16
+	cur := t
+	for i := 0; i < maxDepth; i++ {
+		if cur.PartitionLevelInfo.Level == "p" || cur.PartitionLevelInfo.Level == "" {
+			return cur.Schema + "." + cur.Name
+		}
+		if len(cur.Inherits) == 0 {
+			return cur.Schema + "." + cur.Name
+		}
+		parent, ok := byFQN[cur.Inherits[0]]
+		if !ok {
+			// Parent was filtered out upstream (e.g., --exclude-table). Fall
+			// back to the immediate-parent FQN as the root-equivalent.
+			return cur.Inherits[0]
+		}
+		cur = parent
+	}
+	return cur.Schema + "." + cur.Name
+}
+
+// isCBDBFamilyPath reports whether the source-side path is the modern
+// declarative partition path (GPDB 7+ / CBDB family), where the half-built
+// leaf case can produce silently-divergent ATTACH behavior. On the GP6
+// classical-partition path the inline root CREATE will hard-error before
+// any half-built scenario can take hold, so the check doesn't apply.
+func isCBDBFamilyPath() bool {
+	return (srcDBVersion.IsGPDB() && srcDBVersion.AtLeast("7")) || srcDBVersion.IsCBDBFamily()
+}

--- a/meta/builtin/skip_existing.go
+++ b/meta/builtin/skip_existing.go
@@ -39,10 +39,15 @@ const (
 
 // SkippedTable records one decision made by the --skip-existing filter.
 // Both source-side and destination-side schema/name pairs are kept because
-// they may differ under --schema-mapping.
+// they may differ under --schema-mapping. SourceDbName and DestDbName
+// matter when cbcopy processes more than one db pair in a single run
+// (--full or --dbname db1,db2 mode) so an audit of skip_existing.list can
+// tell entries from different db pairs apart.
 type SkippedTable struct {
+	SourceDbName string
 	SourceSchema string
 	SourceName   string
+	DestDbName   string
 	DestSchema   string
 	DestName     string
 	Reason       SkipReason
@@ -90,10 +95,12 @@ func recordSkip(s SkippedTable) {
 // the partition/inheritance reasoning that FilterTablesByDestExisting
 // performs. The reason is fixed to SkipReasonExists because the caller has
 // already established that the destination row is present.
-func RecordPairSkip(srcSchema, srcName, destSchema, destName string) {
+func RecordPairSkip(srcDbName_ string, srcSchema, srcName string, destDbName_ string, destSchema, destName string) {
 	recordSkip(SkippedTable{
+		SourceDbName: srcDbName_,
 		SourceSchema: srcSchema,
 		SourceName:   srcName,
+		DestDbName:   destDbName_,
 		DestSchema:   destSchema,
 		DestName:     destName,
 		Reason:       SkipReasonExists,
@@ -104,10 +111,14 @@ func RecordPairSkip(srcSchema, srcName, destSchema, destName string) {
 // because of --skip-existing into ~/gpAdminLogs/<timestamp>_skip_existing.list.
 // Layout: one tab-separated line per table —
 //
-//	<reason>	<source_schema>.<source_name>	<dest_schema>.<dest_name>
+//	<reason>	<src_db>.<src_schema>.<src_name>	<dest_db>.<dest_schema>.<dest_name>
 //
-// The file is written once, after all databases have been processed.
-// Returns nil and writes nothing if no tables were skipped.
+// The db name is embedded into the FQN (matching cbcopy's existing
+// <db>.<schema>.<table> convention used by cbcopy_skipped / cbcopy_failed)
+// so that multi-database copies (--full or --dbname db1,db2) can be
+// audited unambiguously. The file is written once, after all databases
+// have been processed. Returns nil and writes nothing if no tables were
+// skipped.
 func WriteSkipExistingList(timestamp string) error {
 	snapshot := SkipExistingTables()
 	if len(snapshot) == 0 {
@@ -128,10 +139,18 @@ func WriteSkipExistingList(timestamp string) error {
 	for _, s := range snapshot {
 		b.WriteString(s.Reason.String())
 		b.WriteByte('\t')
+		if s.SourceDbName != "" {
+			b.WriteString(s.SourceDbName)
+			b.WriteByte('.')
+		}
 		b.WriteString(s.SourceSchema)
 		b.WriteByte('.')
 		b.WriteString(s.SourceName)
 		b.WriteByte('\t')
+		if s.DestDbName != "" {
+			b.WriteString(s.DestDbName)
+			b.WriteByte('.')
+		}
 		b.WriteString(s.DestSchema)
 		b.WriteByte('.')
 		b.WriteString(s.DestName)
@@ -245,8 +264,8 @@ func FilterTablesByDestExisting(tables []Table) []Table {
 			if rootSkip[srcFQN] {
 				ds, dn := runtimeOption.TranslateToDestFQN(t.Schema, t.Name)
 				recordSkip(SkippedTable{
-					SourceSchema: t.Schema, SourceName: t.Name,
-					DestSchema: ds, DestName: dn,
+					SourceDbName: srcDbName, SourceSchema: t.Schema, SourceName: t.Name,
+					DestDbName: destDbName, DestSchema: ds, DestName: dn,
 					Reason: SkipReasonExists,
 				})
 				continue
@@ -256,8 +275,8 @@ func FilterTablesByDestExisting(tables []Table) []Table {
 			if rootSkip[rootFQN] {
 				ds, dn := runtimeOption.TranslateToDestFQN(t.Schema, t.Name)
 				recordSkip(SkippedTable{
-					SourceSchema: t.Schema, SourceName: t.Name,
-					DestSchema: ds, DestName: dn,
+					SourceDbName: srcDbName, SourceSchema: t.Schema, SourceName: t.Name,
+					DestDbName: destDbName, DestSchema: ds, DestName: dn,
 					Reason: SkipReasonRootExists,
 				})
 				continue
@@ -273,8 +292,8 @@ func FilterTablesByDestExisting(tables []Table) []Table {
 					ds, dn := runtimeOption.TranslateToDestFQN(t.Schema, suffixed)
 					if runtimeOption.IsDestTableExisting(destDbName, ds, dn) {
 						recordSkip(SkippedTable{
-							SourceSchema: t.Schema, SourceName: t.Name,
-							DestSchema: ds, DestName: dn,
+							SourceDbName: srcDbName, SourceSchema: t.Schema, SourceName: t.Name,
+							DestDbName: destDbName, DestSchema: ds, DestName: dn,
 							Reason: SkipReasonExists,
 						})
 						continue
@@ -292,8 +311,8 @@ func FilterTablesByDestExisting(tables []Table) []Table {
 						gplog.Warn("[skip-existing] partition leaf %s.%s exists on destination but its root does not; existing leaf will be attached to a freshly created root and may diverge from the source. Inspect the destination cluster before relying on the result.",
 							ds, dn)
 						recordSkip(SkippedTable{
-							SourceSchema: t.Schema, SourceName: t.Name,
-							DestSchema: ds, DestName: dn,
+							SourceDbName: srcDbName, SourceSchema: t.Schema, SourceName: t.Name,
+							DestDbName: destDbName, DestSchema: ds, DestName: dn,
 							Reason: SkipReasonHalfBuiltLeaf,
 						})
 						// Intentionally do not "continue" — the leaf stays in

--- a/meta/builtin/skip_existing_test.go
+++ b/meta/builtin/skip_existing_test.go
@@ -2,8 +2,11 @@ package builtin
 
 import (
 	"os"
+	"os/user"
+	"strings"
 	"testing"
 
+	"github.com/apache/cloudberry-go-libs/operating"
 	"github.com/cloudberry-contrib/cbcopy/internal/dbconn"
 	"github.com/cloudberry-contrib/cbcopy/internal/testhelper"
 	"github.com/cloudberry-contrib/cbcopy/option"
@@ -290,5 +293,85 @@ func TestWalkToRoot_ParentMissingFallsBackToImmediate(t *testing.T) {
 	byFQN := map[string]Table{} // parent not present
 	if got := walkToRoot(leaf, byFQN); got != "public.gone" {
 		t.Fatalf("expected fallback to immediate parent FQN, got %s", got)
+	}
+}
+
+func TestSkipReasonString(t *testing.T) {
+	cases := []struct {
+		r    SkipReason
+		want string
+	}{
+		{SkipReasonExists, "exists"},
+		{SkipReasonRootExists, "root_exists"},
+		{SkipReasonHalfBuiltLeaf, "half_built_leaf"},
+		{SkipReason(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.r.String(); got != tc.want {
+			t.Errorf("SkipReason(%d).String() = %q, want %q", tc.r, got, tc.want)
+		}
+	}
+}
+
+func TestWriteSkipExistingList_EmptyIsNoOp(t *testing.T) {
+	ResetSkipExistingState()
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := WriteSkipExistingList("ts"); err != nil {
+		t.Fatalf("expected no error on empty input, got %v", err)
+	}
+	// Should not create the file at all.
+	path := tmpHome + "/gpAdminLogs/ts_skip_existing.list"
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected no file to be created, got err=%v", err)
+	}
+}
+
+func TestWriteSkipExistingList_PersistsAllEntries(t *testing.T) {
+	ResetSkipExistingState()
+	recordSkip(SkippedTable{
+		SourceSchema: "src_s", SourceName: "t1",
+		DestSchema: "dst_s", DestName: "t1",
+		Reason: SkipReasonExists,
+	})
+	recordSkip(SkippedTable{
+		SourceSchema: "public", SourceName: "rootA",
+		DestSchema: "public", DestName: "rootA",
+		Reason: SkipReasonRootExists,
+	})
+	recordSkip(SkippedTable{
+		SourceSchema: "public", SourceName: "rootA_1_prt_a",
+		DestSchema: "public", DestName: "rootA_1_prt_a",
+		Reason: SkipReasonHalfBuiltLeaf,
+	})
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	// operating.System.CurrentUser may cache; rebind for the test.
+	prevSystem := operating.System
+	operating.System.CurrentUser = func() (*user.User, error) {
+		return &user.User{HomeDir: tmpHome}, nil
+	}
+	defer func() { operating.System = prevSystem }()
+
+	if err := WriteSkipExistingList("20260511_1830"); err != nil {
+		t.Fatalf("WriteSkipExistingList: %v", err)
+	}
+	path := tmpHome + "/gpAdminLogs/20260511_1830_skip_existing.list"
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read produced file: %v", err)
+	}
+	body := string(raw)
+	wants := []string{
+		"exists\tsrc_s.t1\tdst_s.t1",
+		"root_exists\tpublic.rootA\tpublic.rootA",
+		"half_built_leaf\tpublic.rootA_1_prt_a\tpublic.rootA_1_prt_a",
+	}
+	for _, w := range wants {
+		if !strings.Contains(body, w) {
+			t.Errorf("expected file to contain %q, got:\n%s", w, body)
+		}
 	}
 }

--- a/meta/builtin/skip_existing_test.go
+++ b/meta/builtin/skip_existing_test.go
@@ -1,0 +1,294 @@
+package builtin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudberry-contrib/cbcopy/internal/dbconn"
+	"github.com/cloudberry-contrib/cbcopy/internal/testhelper"
+	"github.com/cloudberry-contrib/cbcopy/option"
+	"github.com/cloudberry-contrib/cbcopy/utils"
+	"github.com/spf13/pflag"
+)
+
+func TestMain(m *testing.M) {
+	// Initialize gplog with in-memory buffers so production logging calls
+	// (Info/Warn/Debug) don't dereference a nil writer at test time.
+	testhelper.SetupTestLogger()
+	os.Exit(m.Run())
+}
+
+// installSkipExistingTestFixtures wires up the package-level state that
+// FilterTablesByDestExisting reads from. Callers pass the destination
+// inventory + root-partition inventory as plain maps; the helper builds
+// an *option.Option around them and installs srcDBVersion accordingly.
+func installSkipExistingTestFixtures(t *testing.T, srcVer dbconn.GPDBVersion, destDb string, inv, parts map[string]struct{}) {
+	t.Helper()
+
+	srcDBVersion = srcVer
+	destDbName = destDb
+
+	o := &option.Option{}
+	// Populate using the public MarkDestTables path so we exercise the same
+	// code that production does. Convert the test fixture maps to the shapes
+	// MarkDestTables expects.
+	userTables := make(map[string]option.TableStatistics, len(inv))
+	for k := range inv {
+		userTables[k] = option.TableStatistics{}
+	}
+	partTables := make(map[string]bool, len(parts))
+	for k := range parts {
+		partTables[k] = true
+	}
+	// MarkDestTables requires destDbInventory/destDbRootParts to be initialized.
+	// option.NewOption does this for real callers; the test sets it directly.
+	setInventories(o, destDb, userTables, partTables)
+	runtimeOption = o
+
+	// Install a pflag.FlagSet that has SKIP_EXISTING registered and set to
+	// true (so MustGetFlagBool returns true).
+	fs := pflag.NewFlagSet("skip-existing-test", pflag.ContinueOnError)
+	fs.Bool(option.SKIP_EXISTING, true, "")
+	utils.SetCmdFlags(fs)
+
+	ResetSkipExistingState()
+}
+
+// setInventories bypasses MarkDestTables (which requires the maps to already
+// exist) so tests can directly seed an Option fixture.
+func setInventories(o *option.Option, destDb string, userTables map[string]option.TableStatistics, partTables map[string]bool) {
+	// Use the exported MarkDestTables after seeding the maps via NewOption
+	// would normally be the path, but for tests we shortcut by ensuring the
+	// maps are non-nil first. Since fields are unexported, do this via
+	// option.NewOption indirectly: build an Option that has empty maps, then
+	// call MarkDestTables.
+	o2 := newOptionWithEmptyInventories()
+	*o = *o2
+	o.MarkDestTables(destDb, userTables, partTables)
+}
+
+// newOptionWithEmptyInventories returns a fresh *Option whose inventory maps
+// are initialized but empty. Constructed via NewOption with a minimal flag
+// set to avoid touching real config paths.
+func newOptionWithEmptyInventories() *option.Option {
+	fs := pflag.NewFlagSet("init", pflag.ContinueOnError)
+	// NewOption reads several flags; register the ones it touches.
+	fs.StringSlice(option.DBNAME, []string{}, "")
+	fs.StringSlice(option.DEST_DBNAME, []string{}, "")
+	fs.StringSlice(option.EXCLUDE_TABLE, []string{}, "")
+	fs.String(option.EXCLUDE_TABLE_FILE, "", "")
+	fs.StringSlice(option.INCLUDE_TABLE, []string{}, "")
+	fs.String(option.INCLUDE_TABLE_FILE, "", "")
+	fs.StringSlice(option.DEST_TABLE, []string{}, "")
+	fs.String(option.DEST_TABLE_FILE, "", "")
+	fs.Bool(option.APPEND, false, "")
+	fs.Bool(option.SKIP_EXISTING, false, "")
+	fs.StringSlice(option.SCHEMA, []string{}, "")
+	fs.StringSlice(option.DEST_SCHEMA, []string{}, "")
+	fs.String(option.SCHEMA_MAPPING_FILE, "", "")
+	fs.String(option.OWNER_MAPPING_FILE, "", "")
+	fs.String(option.DEST_TABLESPACE, "", "")
+	fs.String(option.TABLESPACE_MAPPING_FILE, "", "")
+	fs.String(option.CONNECTION_MODE, "push", "")
+	o, err := option.NewOption(fs)
+	if err != nil {
+		panic(err)
+	}
+	return o
+}
+
+func mkTable(schema, name, level string, inherits []string, isExternal bool) Table {
+	return Table{
+		Relation: Relation{Schema: schema, Name: name},
+		TableDefinition: TableDefinition{
+			PartitionLevelInfo: PartitionLevelInfo{Level: level},
+			Inherits:           inherits,
+			IsExternal:         isExternal,
+		},
+	}
+}
+
+func TestFilter_FlagOff_NoOp(t *testing.T) {
+	srcDBVersion = dbconn.NewVersion("7.0.0")
+	destDbName = "dst"
+	runtimeOption = newOptionWithEmptyInventories()
+	fs := pflag.NewFlagSet("off", pflag.ContinueOnError)
+	fs.Bool(option.SKIP_EXISTING, false, "")
+	utils.SetCmdFlags(fs)
+	ResetSkipExistingState()
+
+	tables := []Table{mkTable("public", "t1", "", nil, false)}
+	got := FilterTablesByDestExisting(tables)
+	if len(got) != 1 || got[0].Name != "t1" {
+		t.Fatalf("expected input passthrough when --skip-existing is off, got %+v", got)
+	}
+	if NumSkipExisting() != 0 {
+		t.Fatalf("expected 0 recorded skips, got %d", NumSkipExisting())
+	}
+}
+
+func TestFilter_RegularTableExists_Skipped(t *testing.T) {
+	cbdb := dbconn.GPDBVersion{Type: dbconn.CBDB}
+	installSkipExistingTestFixtures(t, cbdb, "dst",
+		map[string]struct{}{"public.t1": {}},
+		map[string]struct{}{},
+	)
+
+	tables := []Table{
+		mkTable("public", "t1", "", nil, false),
+		mkTable("public", "t2", "", nil, false),
+	}
+	got := FilterTablesByDestExisting(tables)
+	if len(got) != 1 || got[0].Name != "t2" {
+		t.Fatalf("expected only t2 kept, got %+v", got)
+	}
+	if NumSkipExisting() != 1 {
+		t.Fatalf("expected 1 recorded skip, got %d", NumSkipExisting())
+	}
+	if SkipExistingTables()[0].Reason != SkipReasonExists {
+		t.Fatalf("expected SkipReasonExists, got %v", SkipExistingTables()[0].Reason)
+	}
+}
+
+func TestFilter_PartitionRootExists_TreeSkipped(t *testing.T) {
+	cbdb := dbconn.GPDBVersion{Type: dbconn.CBDB}
+	installSkipExistingTestFixtures(t, cbdb, "dst",
+		map[string]struct{}{},
+		map[string]struct{}{"public.root1": {}},
+	)
+
+	tables := []Table{
+		mkTable("public", "root1", "p", nil, false),
+		mkTable("public", "root1_1_prt_a", "l", []string{"public.root1"}, false),
+		mkTable("public", "root1_1_prt_b", "l", []string{"public.root1"}, false),
+		mkTable("public", "t_other", "", nil, false),
+	}
+	got := FilterTablesByDestExisting(tables)
+	if len(got) != 1 || got[0].Name != "t_other" {
+		t.Fatalf("expected only t_other kept, got %+v", got)
+	}
+	if NumSkipExisting() != 3 {
+		t.Fatalf("expected 3 recorded skips (root + 2 leaves), got %d", NumSkipExisting())
+	}
+}
+
+func TestFilter_PartitionRootMissing_AllKept(t *testing.T) {
+	cbdb := dbconn.GPDBVersion{Type: dbconn.CBDB}
+	installSkipExistingTestFixtures(t, cbdb, "dst",
+		map[string]struct{}{},
+		map[string]struct{}{},
+	)
+
+	tables := []Table{
+		mkTable("public", "root1", "p", nil, false),
+		mkTable("public", "root1_1_prt_a", "l", []string{"public.root1"}, false),
+	}
+	got := FilterTablesByDestExisting(tables)
+	if len(got) != 2 {
+		t.Fatalf("expected all 2 kept, got %d", len(got))
+	}
+	if NumSkipExisting() != 0 {
+		t.Fatalf("expected 0 recorded skips, got %d", NumSkipExisting())
+	}
+}
+
+func TestFilter_CBHalfBuiltLeaf_WarnAndKeep(t *testing.T) {
+	// CB-family source, root absent on dest, but leaf is present.
+	cbdb := dbconn.GPDBVersion{Type: dbconn.CBDB}
+	installSkipExistingTestFixtures(t, cbdb, "dst",
+		map[string]struct{}{"public.root1_1_prt_a": {}}, // leaf exists
+		map[string]struct{}{},                            // root does NOT
+	)
+
+	tables := []Table{
+		mkTable("public", "root1", "p", nil, false),
+		mkTable("public", "root1_1_prt_a", "l", []string{"public.root1"}, false),
+	}
+	got := FilterTablesByDestExisting(tables)
+	// Both should be kept: the existing pipeline handles the conflict at DDL
+	// execution time. Filter records a half-built skip for reporting.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 kept (half-built case keeps leaf in plan), got %d", len(got))
+	}
+	if NumSkipExisting() != 1 {
+		t.Fatalf("expected 1 recorded half-built skip, got %d", NumSkipExisting())
+	}
+	if SkipExistingTables()[0].Reason != SkipReasonHalfBuiltLeaf {
+		t.Fatalf("expected SkipReasonHalfBuiltLeaf, got %v", SkipExistingTables()[0].Reason)
+	}
+}
+
+func TestFilter_GP6ExternalLeafSuffix_SkippedBySuffixedName(t *testing.T) {
+	// GP6 source: external partition leaf is emitted with "_ext_part_" suffix
+	// on the destination. Existence check must use the suffixed name.
+	gp6 := dbconn.NewVersion("6.20.0") // Type = GPDB by NewVersion
+	installSkipExistingTestFixtures(t, gp6, "dst",
+		map[string]struct{}{"public.ext_leaf_ext_part_": {}},
+		map[string]struct{}{},
+	)
+
+	tables := []Table{
+		mkTable("public", "root1", "p", nil, false),
+		mkTable("public", "ext_leaf", "l", []string{"public.root1"}, true),
+	}
+	got := FilterTablesByDestExisting(tables)
+	// Root is absent on dest, so root + non-external leaves would be kept;
+	// the external leaf should be filtered out because its suffixed name
+	// exists on the destination.
+	if len(got) != 1 || got[0].Name != "root1" {
+		t.Fatalf("expected only root1 kept (external leaf filtered by suffix), got %+v", got)
+	}
+	if NumSkipExisting() != 1 {
+		t.Fatalf("expected 1 recorded skip, got %d", NumSkipExisting())
+	}
+}
+
+func TestWalkToRoot_NonPartitionReturnsSelf(t *testing.T) {
+	byFQN := map[string]Table{}
+	t1 := mkTable("public", "t1", "", nil, false)
+	if got := walkToRoot(t1, byFQN); got != "public.t1" {
+		t.Fatalf("expected public.t1, got %s", got)
+	}
+}
+
+func TestWalkToRoot_PartitionRootReturnsSelf(t *testing.T) {
+	byFQN := map[string]Table{}
+	r := mkTable("public", "root1", "p", nil, false)
+	if got := walkToRoot(r, byFQN); got != "public.root1" {
+		t.Fatalf("expected public.root1, got %s", got)
+	}
+}
+
+func TestWalkToRoot_LeafFollowsInherits(t *testing.T) {
+	root := mkTable("public", "root1", "p", nil, false)
+	leaf := mkTable("public", "root1_1_prt_a", "l", []string{"public.root1"}, false)
+	byFQN := map[string]Table{
+		"public.root1":           root,
+		"public.root1_1_prt_a":   leaf,
+	}
+	if got := walkToRoot(leaf, byFQN); got != "public.root1" {
+		t.Fatalf("expected public.root1, got %s", got)
+	}
+}
+
+func TestWalkToRoot_LeafThroughIntermediate(t *testing.T) {
+	root := mkTable("public", "root1", "p", nil, false)
+	mid := mkTable("public", "root1_1_prt_q1", "i", []string{"public.root1"}, false)
+	leaf := mkTable("public", "root1_1_prt_q1_2_prt_jan", "l", []string{"public.root1_1_prt_q1"}, false)
+	byFQN := map[string]Table{
+		"public.root1":                          root,
+		"public.root1_1_prt_q1":                 mid,
+		"public.root1_1_prt_q1_2_prt_jan":       leaf,
+	}
+	if got := walkToRoot(leaf, byFQN); got != "public.root1" {
+		t.Fatalf("expected public.root1 (through intermediate), got %s", got)
+	}
+}
+
+func TestWalkToRoot_ParentMissingFallsBackToImmediate(t *testing.T) {
+	leaf := mkTable("public", "orphan_leaf", "l", []string{"public.gone"}, false)
+	byFQN := map[string]Table{} // parent not present
+	if got := walkToRoot(leaf, byFQN); got != "public.gone" {
+		t.Fatalf("expected fallback to immediate parent FQN, got %s", got)
+	}
+}

--- a/meta/builtin/skip_existing_test.go
+++ b/meta/builtin/skip_existing_test.go
@@ -30,11 +30,14 @@ func ensureTestLogger() {
 // FilterTablesByDestExisting reads from. Callers pass the destination
 // inventory + root-partition inventory as plain maps; the helper builds
 // an *option.Option around them and installs srcDBVersion accordingly.
+// The source db name is fixed to "src" — tests that don't care about
+// the source db column don't need to look at it.
 func installSkipExistingTestFixtures(t *testing.T, srcVer dbconn.GPDBVersion, destDb string, inv, parts map[string]struct{}) {
 	t.Helper()
 	ensureTestLogger()
 
 	srcDBVersion = srcVer
+	srcDbName = "src"
 	destDbName = destDb
 
 	o := &option.Option{}
@@ -340,18 +343,18 @@ func TestWriteSkipExistingList_PersistsAllEntries(t *testing.T) {
 	ensureTestLogger()
 	ResetSkipExistingState()
 	recordSkip(SkippedTable{
-		SourceSchema: "src_s", SourceName: "t1",
-		DestSchema: "dst_s", DestName: "t1",
+		SourceDbName: "prod", SourceSchema: "src_s", SourceName: "t1",
+		DestDbName: "prod_new", DestSchema: "dst_s", DestName: "t1",
 		Reason: SkipReasonExists,
 	})
 	recordSkip(SkippedTable{
-		SourceSchema: "public", SourceName: "rootA",
-		DestSchema: "public", DestName: "rootA",
+		SourceDbName: "staging", SourceSchema: "public", SourceName: "rootA",
+		DestDbName: "staging_new", DestSchema: "public", DestName: "rootA",
 		Reason: SkipReasonRootExists,
 	})
 	recordSkip(SkippedTable{
-		SourceSchema: "public", SourceName: "rootA_1_prt_a",
-		DestSchema: "public", DestName: "rootA_1_prt_a",
+		SourceDbName: "prod", SourceSchema: "public", SourceName: "rootA_1_prt_a",
+		DestDbName: "prod_new", DestSchema: "public", DestName: "rootA_1_prt_a",
 		Reason: SkipReasonHalfBuiltLeaf,
 	})
 
@@ -377,13 +380,46 @@ func TestWriteSkipExistingList_PersistsAllEntries(t *testing.T) {
 	}
 	body := string(raw)
 	wants := []string{
-		"exists\tsrc_s.t1\tdst_s.t1",
-		"root_exists\tpublic.rootA\tpublic.rootA",
-		"half_built_leaf\tpublic.rootA_1_prt_a\tpublic.rootA_1_prt_a",
+		"exists\tprod.src_s.t1\tprod_new.dst_s.t1",
+		"root_exists\tstaging.public.rootA\tstaging_new.public.rootA",
+		"half_built_leaf\tprod.public.rootA_1_prt_a\tprod_new.public.rootA_1_prt_a",
 	}
 	for _, w := range wants {
 		if !strings.Contains(body, w) {
 			t.Errorf("expected file to contain %q, got:\n%s", w, body)
 		}
+	}
+}
+
+func TestWriteSkipExistingList_OmitsEmptyDbName(t *testing.T) {
+	// Defensive: if a record was produced without a db name (e.g., a code
+	// path that doesn't have it), the writer should still produce a valid
+	// FQN, falling back to "<schema>.<name>" instead of ".schema.name".
+	ensureTestLogger()
+	ResetSkipExistingState()
+	recordSkip(SkippedTable{
+		SourceSchema: "public", SourceName: "t1",
+		DestSchema: "public", DestName: "t1",
+		Reason: SkipReasonExists,
+	})
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	prevCurrentUser := operating.System.CurrentUser
+	operating.System.CurrentUser = func() (*user.User, error) {
+		return &user.User{HomeDir: tmpHome}, nil
+	}
+	defer func() { operating.System.CurrentUser = prevCurrentUser }()
+
+	if err := WriteSkipExistingList("no-db"); err != nil {
+		t.Fatalf("WriteSkipExistingList: %v", err)
+	}
+	raw, err := os.ReadFile(tmpHome + "/gpAdminLogs/no-db_skip_existing.list")
+	if err != nil {
+		t.Fatalf("read produced file: %v", err)
+	}
+	want := "exists\tpublic.t1\tpublic.t1"
+	if !strings.Contains(string(raw), want) {
+		t.Errorf("expected file to contain %q, got:\n%s", want, string(raw))
 	}
 }

--- a/meta/builtin/skip_existing_test.go
+++ b/meta/builtin/skip_existing_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/cloudberry-go-libs/operating"
@@ -14,11 +15,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func TestMain(m *testing.M) {
-	// Initialize gplog with in-memory buffers so production logging calls
-	// (Info/Warn/Debug) don't dereference a nil writer at test time.
-	testhelper.SetupTestLogger()
-	os.Exit(m.Run())
+// testLoggerOnce ensures gplog has in-memory writers installed exactly once
+// across all tests in this file, without contending with the Ginkgo
+// BeforeEach in backup_suite_test.go that also touches the gplog singleton.
+var testLoggerOnce sync.Once
+
+func ensureTestLogger() {
+	testLoggerOnce.Do(func() {
+		testhelper.SetupTestLogger()
+	})
 }
 
 // installSkipExistingTestFixtures wires up the package-level state that
@@ -27,6 +32,7 @@ func TestMain(m *testing.M) {
 // an *option.Option around them and installs srcDBVersion accordingly.
 func installSkipExistingTestFixtures(t *testing.T, srcVer dbconn.GPDBVersion, destDb string, inv, parts map[string]struct{}) {
 	t.Helper()
+	ensureTestLogger()
 
 	srcDBVersion = srcVer
 	destDbName = destDb
@@ -112,6 +118,7 @@ func mkTable(schema, name, level string, inherits []string, isExternal bool) Tab
 }
 
 func TestFilter_FlagOff_NoOp(t *testing.T) {
+	ensureTestLogger()
 	srcDBVersion = dbconn.NewVersion("7.0.0")
 	destDbName = "dst"
 	runtimeOption = newOptionWithEmptyInventories()
@@ -314,6 +321,7 @@ func TestSkipReasonString(t *testing.T) {
 }
 
 func TestWriteSkipExistingList_EmptyIsNoOp(t *testing.T) {
+	ensureTestLogger()
 	ResetSkipExistingState()
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
@@ -329,6 +337,7 @@ func TestWriteSkipExistingList_EmptyIsNoOp(t *testing.T) {
 }
 
 func TestWriteSkipExistingList_PersistsAllEntries(t *testing.T) {
+	ensureTestLogger()
 	ResetSkipExistingState()
 	recordSkip(SkippedTable{
 		SourceSchema: "src_s", SourceName: "t1",
@@ -348,12 +357,15 @@ func TestWriteSkipExistingList_PersistsAllEntries(t *testing.T) {
 
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
-	// operating.System.CurrentUser may cache; rebind for the test.
-	prevSystem := operating.System
+	// operating.System is a *SystemFunctions, so we must swap the field
+	// directly (not the whole pointer) and restore the same field on exit;
+	// otherwise the override leaks into other tests in the binary and breaks
+	// dbconn.NewDBConnFromEnvironment in the Ginkgo BeforeEach.
+	prevCurrentUser := operating.System.CurrentUser
 	operating.System.CurrentUser = func() (*user.User, error) {
 		return &user.User{HomeDir: tmpHome}, nil
 	}
-	defer func() { operating.System = prevSystem }()
+	defer func() { operating.System.CurrentUser = prevCurrentUser }()
 
 	if err := WriteSkipExistingList("20260511_1830"); err != nil {
 		t.Fatalf("WriteSkipExistingList: %v", err)

--- a/meta/builtin/variables.go
+++ b/meta/builtin/variables.go
@@ -20,6 +20,17 @@ var (
 	srcDBVersion  dbconn.GPDBVersion
 	destDBVersion dbconn.GPDBVersion
 
+	// destDbName is the name of the destination database currently being
+	// processed. Set by BuiltinMeta.Open; consumed by FilterTablesByDestExisting
+	// (and any future logic that needs to ask "does this table exist on dest?").
+	destDbName string
+
+	// runtimeOption is a handle to the global *option.Option used by
+	// non-pure-flag-driven decisions inside meta/builtin, primarily the
+	// --skip-existing existence check. Set by SetOption from the copy package
+	// once option.NewOption has produced an Option instance.
+	runtimeOption *option.Option
+
 	// --> automation test purpose, start
 	cmdFlags *pflag.FlagSet
 	// <-- automation test purpose, end
@@ -42,6 +53,13 @@ var (
 	destTablespace    string
 	destTablespaceMap map[string]string
 )
+
+// SetOption installs the runtime *option.Option for use by meta/builtin
+// helpers that need to consult Option state (e.g. --skip-existing existence
+// checks). Call after option.NewOption returns. Mirrors utils.SetCmdFlags.
+func SetOption(o *option.Option) {
+	runtimeOption = o
+}
 
 // --> automation test purpose, start
 func SetCmdFlags(flagSet *pflag.FlagSet) {

--- a/meta/builtin/variables.go
+++ b/meta/builtin/variables.go
@@ -20,9 +20,12 @@ var (
 	srcDBVersion  dbconn.GPDBVersion
 	destDBVersion dbconn.GPDBVersion
 
-	// destDbName is the name of the destination database currently being
-	// processed. Set by BuiltinMeta.Open; consumed by FilterTablesByDestExisting
-	// (and any future logic that needs to ask "does this table exist on dest?").
+	// srcDbName and destDbName name the source and destination databases
+	// currently being processed. Set by BuiltinMeta.Open; consumed by
+	// FilterTablesByDestExisting and the skip-existing recorder so each
+	// recorded entry knows which db pair it belongs to (relevant in
+	// multi-db copy modes like --full or --dbname db1,db2).
+	srcDbName  string
 	destDbName string
 
 	// runtimeOption is a handle to the global *option.Option used by

--- a/option/option.go
+++ b/option/option.go
@@ -40,6 +40,7 @@ const (
 	SOURCE_HOST             = "source-host"
 	SOURCE_PORT             = "source-port"
 	SOURCE_USER             = "source-user"
+	SKIP_EXISTING           = "skip-existing"
 	TRUNCATE                = "truncate"
 	VALIDATE                = "validate"
 	SCHEMA                  = "schema"
@@ -73,8 +74,9 @@ const (
 )
 
 const (
-	TableModeTruncate = "truncate"
-	TableModeAppend   = "append"
+	TableModeTruncate     = "truncate"
+	TableModeAppend       = "append"
+	TableModeSkipExisting = "skip-existing"
 )
 
 type DbTable struct {
@@ -171,6 +173,9 @@ func NewOption(initialFlags *pflag.FlagSet) (*Option, error) {
 
 	if append, _ := initialFlags.GetBool(APPEND); append {
 		tableMode = TableModeAppend
+	}
+	if skipExisting, _ := initialFlags.GetBool(SKIP_EXISTING); skipExisting {
+		tableMode = TableModeSkipExisting
 	}
 
 	ownerMap, err := getOwnerMap(initialFlags)

--- a/option/option.go
+++ b/option/option.go
@@ -457,7 +457,7 @@ func (o Option) MarkIncludeTables(dbname string, userTables map[string]TableStat
 	o.markTables(dbname, o.includedTables, userTables, partTables)
 }
 
-func (o Option) MarkDestTables(dbname string, userTables map[string]TableStatistics, partTables map[string]bool) {
+func (o *Option) MarkDestTables(dbname string, userTables map[string]TableStatistics, partTables map[string]bool) {
 	o.markTables(dbname, o.destTables, userTables, partTables)
 
 	// Persist a snapshot of the destination-side table inventory so that
@@ -482,7 +482,7 @@ func (o Option) MarkDestTables(dbname string, userTables map[string]TableStatist
 // definitions are not compared (matching gpcopy's --skip-existing semantics).
 // Root-partition tables are also recognized, so this returns true for the
 // root of a partition tree even if it was not listed in GetUserTables.
-func (o Option) IsDestTableExisting(destDbName, destSchema, destName string) bool {
+func (o *Option) IsDestTableExisting(destDbName, destSchema, destName string) bool {
 	fqn := destSchema + "." + destName
 	if inv, ok := o.destDbInventory[destDbName]; ok {
 		if _, exists := inv[fqn]; exists {
@@ -502,7 +502,7 @@ func (o Option) IsDestTableExisting(destDbName, destSchema, destName string) boo
 // If no mapping applies (e.g., db-mode or full-mode without --schema-mapping),
 // the source schema is returned unchanged, mirroring cbcopy's default of
 // "same schema on both sides".
-func (o Option) TranslateToDestFQN(srcSchema, srcName string) (string, string) {
+func (o *Option) TranslateToDestFQN(srcSchema, srcName string) (string, string) {
 	schemaMap := o.GetSchemaMap()
 	if destSchema, ok := schemaMap[srcSchema]; ok && destSchema != "" {
 		return destSchema, srcName

--- a/option/option.go
+++ b/option/option.go
@@ -125,6 +125,15 @@ type Option struct {
 
 	ownerMap      map[string]string
 	tablespaceMap map[string]string
+
+	// destDbInventory is a per-destination-database snapshot of the user tables
+	// present on the destination cluster, keyed by db name and then by
+	// "schema.name" FQN. Populated by MarkDestTables. Used by IsDestTableExisting
+	// to support --skip-existing without re-querying the destination.
+	destDbInventory map[string]map[string]struct{}
+	// destDbRootParts mirrors destDbInventory but lists the root-partition tables
+	// (which may not appear in destDbInventory on every supported version).
+	destDbRootParts map[string]map[string]struct{}
 }
 
 func NewOption(initialFlags *pflag.FlagSet) (*Option, error) {
@@ -189,18 +198,20 @@ func NewOption(initialFlags *pflag.FlagSet) (*Option, error) {
 	}
 
 	return &Option{
-		copyMode:       copyMode,
-		tableMode:      tableMode,
-		connectionMode: connectionMode,
-		sourceDbnames:  sourceDbnames,
-		destDbnames:    destDbnames,
-		excludedTables: excludeTables,
-		includedTables: includeTables,
-		destTables:     destTables,
-		sourceSchemas:  sourceSchemas,
-		destSchemas:    destSchemas,
-		ownerMap:       ownerMap,
-		tablespaceMap:  tablespaceMap,
+		copyMode:        copyMode,
+		tableMode:       tableMode,
+		connectionMode:  connectionMode,
+		sourceDbnames:   sourceDbnames,
+		destDbnames:     destDbnames,
+		excludedTables:  excludeTables,
+		includedTables:  includeTables,
+		destTables:      destTables,
+		sourceSchemas:   sourceSchemas,
+		destSchemas:     destSchemas,
+		ownerMap:        ownerMap,
+		tablespaceMap:   tablespaceMap,
+		destDbInventory: make(map[string]map[string]struct{}),
+		destDbRootParts: make(map[string]map[string]struct{}),
 	}, nil
 }
 
@@ -448,6 +459,55 @@ func (o Option) MarkIncludeTables(dbname string, userTables map[string]TableStat
 
 func (o Option) MarkDestTables(dbname string, userTables map[string]TableStatistics, partTables map[string]bool) {
 	o.markTables(dbname, o.destTables, userTables, partTables)
+
+	// Persist a snapshot of the destination-side table inventory so that
+	// IsDestTableExisting can answer queries later without a second
+	// round-trip. Map keys mirror what markTables uses: "schema.name" FQN.
+	inv := make(map[string]struct{}, len(userTables))
+	for k := range userTables {
+		inv[k] = struct{}{}
+	}
+	o.destDbInventory[dbname] = inv
+
+	parts := make(map[string]struct{}, len(partTables))
+	for k := range partTables {
+		parts[k] = struct{}{}
+	}
+	o.destDbRootParts[dbname] = parts
+}
+
+// IsDestTableExisting reports whether a table with the given (already
+// schema-mapping-translated) destination schema and name is present in the
+// destination database. The check is by fully-qualified name only; column
+// definitions are not compared (matching gpcopy's --skip-existing semantics).
+// Root-partition tables are also recognized, so this returns true for the
+// root of a partition tree even if it was not listed in GetUserTables.
+func (o Option) IsDestTableExisting(destDbName, destSchema, destName string) bool {
+	fqn := destSchema + "." + destName
+	if inv, ok := o.destDbInventory[destDbName]; ok {
+		if _, exists := inv[fqn]; exists {
+			return true
+		}
+	}
+	if parts, ok := o.destDbRootParts[destDbName]; ok {
+		if _, exists := parts[fqn]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+// TranslateToDestFQN converts a source-side (schema, name) pair into the
+// corresponding destination-side pair after applying --schema-mapping rules.
+// If no mapping applies (e.g., db-mode or full-mode without --schema-mapping),
+// the source schema is returned unchanged, mirroring cbcopy's default of
+// "same schema on both sides".
+func (o Option) TranslateToDestFQN(srcSchema, srcName string) (string, string) {
+	schemaMap := o.GetSchemaMap()
+	if destSchema, ok := schemaMap[srcSchema]; ok && destSchema != "" {
+		return destSchema, srcName
+	}
+	return srcSchema, srcName
 }
 
 func (o Option) MarkExcludeTables(dbname string, userTables map[string]TableStatistics, partTables map[string]bool) {

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -1,0 +1,123 @@
+package option
+
+import "testing"
+
+func newOptionForTest() *Option {
+	return &Option{
+		destDbInventory: make(map[string]map[string]struct{}),
+		destDbRootParts: make(map[string]map[string]struct{}),
+	}
+}
+
+func TestMarkDestTablesPersistsInventory(t *testing.T) {
+	o := newOptionForTest()
+
+	userTables := map[string]TableStatistics{
+		"public.t1": {RelTuples: 100},
+		"sales.q1":  {RelTuples: 200},
+	}
+	partTables := map[string]bool{
+		"public.partroot": true,
+	}
+
+	o.MarkDestTables("dst", userTables, partTables)
+
+	if !o.IsDestTableExisting("dst", "public", "t1") {
+		t.Fatalf("expected public.t1 to be reported as existing")
+	}
+	if !o.IsDestTableExisting("dst", "sales", "q1") {
+		t.Fatalf("expected sales.q1 to be reported as existing")
+	}
+	if !o.IsDestTableExisting("dst", "public", "partroot") {
+		t.Fatalf("expected root partition public.partroot to be reported as existing")
+	}
+}
+
+func TestIsDestTableExistingMisses(t *testing.T) {
+	o := newOptionForTest()
+	o.MarkDestTables("dst", map[string]TableStatistics{
+		"public.t1": {},
+	}, map[string]bool{})
+
+	cases := []struct {
+		name           string
+		db, schema, tn string
+	}{
+		{"unknown table", "dst", "public", "missing"},
+		{"unknown schema", "dst", "other", "t1"},
+		{"unknown db", "other_dst", "public", "t1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if o.IsDestTableExisting(tc.db, tc.schema, tc.tn) {
+				t.Fatalf("expected %s.%s on db %s to be reported as not existing", tc.schema, tc.tn, tc.db)
+			}
+		})
+	}
+}
+
+func TestIsDestTableExistingNoInventoryYet(t *testing.T) {
+	// Brand-new Option, MarkDestTables not yet called: every query should miss.
+	o := newOptionForTest()
+	if o.IsDestTableExisting("any", "any", "any") {
+		t.Fatalf("expected no hits on an Option whose inventory was never populated")
+	}
+}
+
+func TestTranslateToDestFQNNoMapping(t *testing.T) {
+	o := newOptionForTest()
+	// sourceSchemas/destSchemas are nil → GetSchemaMap returns empty map → identity.
+	schema, name := o.TranslateToDestFQN("public", "t1")
+	if schema != "public" || name != "t1" {
+		t.Fatalf("expected (public, t1), got (%s, %s)", schema, name)
+	}
+}
+
+func TestTranslateToDestFQNWithMapping(t *testing.T) {
+	o := newOptionForTest()
+	o.sourceSchemas = []*DbSchema{
+		{Database: "srcdb", Schema: "src_a"},
+		{Database: "srcdb", Schema: "src_b"},
+	}
+	o.destSchemas = []*DbSchema{
+		{Database: "dstdb", Schema: "dst_a"},
+		{Database: "dstdb", Schema: "dst_b"},
+	}
+
+	cases := []struct {
+		srcSchema, srcName     string
+		wantSchema, wantName   string
+	}{
+		{"src_a", "t1", "dst_a", "t1"},
+		{"src_b", "q2", "dst_b", "q2"},
+		{"unmapped", "t3", "unmapped", "t3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.srcSchema, func(t *testing.T) {
+			gotSchema, gotName := o.TranslateToDestFQN(tc.srcSchema, tc.srcName)
+			if gotSchema != tc.wantSchema || gotName != tc.wantName {
+				t.Fatalf("expected (%s, %s), got (%s, %s)", tc.wantSchema, tc.wantName, gotSchema, gotName)
+			}
+		})
+	}
+}
+
+func TestIsDestTableExistingPerDbIsolation(t *testing.T) {
+	o := newOptionForTest()
+	o.MarkDestTables("db_a", map[string]TableStatistics{
+		"public.only_in_a": {},
+	}, map[string]bool{})
+	o.MarkDestTables("db_b", map[string]TableStatistics{
+		"public.only_in_b": {},
+	}, map[string]bool{})
+
+	if !o.IsDestTableExisting("db_a", "public", "only_in_a") {
+		t.Fatalf("expected db_a.public.only_in_a to exist")
+	}
+	if o.IsDestTableExisting("db_a", "public", "only_in_b") {
+		t.Fatalf("expected db_a.public.only_in_b to NOT exist (it is on db_b)")
+	}
+	if !o.IsDestTableExisting("db_b", "public", "only_in_b") {
+		t.Fatalf("expected db_b.public.only_in_b to exist")
+	}
+}


### PR DESCRIPTION
Closes #17.

## Change logs

Adds a new `--skip-existing` option to cbcopy, aligned with VMware/Broadcom gpcopy's option of the same name: when set, tables that already exist on the destination database are skipped (no DDL, no COPY, no owner/ACL changes). Existence is checked by fully-qualified name; column definitions are not compared. For partitioned tables the check is by root-table FQN, so an entire partition tree is skipped when the root exists.

The PR is intentionally large; it bundles what would otherwise be 4-5 small PRs because reviewing the skip logic without its observability or test coverage isn't useful in isolation. To keep it reviewable, the seven commits are organized so each can be read independently:

1. **`feat(option): add --skip-existing flag (CLI & mutex validation only)`** — CLI surface and mutex. Adds the `--skip-existing` boolean flag and the `TableModeSkipExisting` enum value. Tightens `validateTableMode()` to enforce **exactly one** of `--truncate` / `--append` / `--skip-existing`; the previous error message already claimed "one and only one", but the check only enforced "at least one", so passing both `--truncate` and `--append` used to silently resolve to `--append`. Keeps the existing `--metadata-only` / `--global-metadata-only` bypass. Adds unit tests covering all 8 combinations of the three flags plus the two bypass modes (11 cases total). Updates README's "Data Loading Modes" section and the Flags table. No runtime behavior change from this commit alone.

2. **`feat(option): persist dest table inventory + add existence accessors`** — Foundation. Extends `MarkDestTables` to also persist the destination-side table inventory it already receives (it was being consumed and discarded), and adds `IsDestTableExisting` / `TranslateToDestFQN` methods. No runtime behavior change yet — nothing reads the accessors in this commit.

3. **`feat(meta): filter tables that already exist on destination`** — DDL pipeline filter. `FilterTablesByDestExisting` is called from `RetrieveAndProcessTables` before metadata extraction, so skipped tables produce no DDL / ACL / owner / comment statements downstream. Covers Full / Db / Schema / Table-without-`--dest-table` modes. Handles regular tables, partition root (whole tree skipped), partition leaf/intermediate (root authoritative via `Table.Inherits` walk), CB-family half-built leaves (WARN-and-keep, matches gpcopy behavior), and the GP6 external-partition `_ext_part_` suffix quirk.

4. **`feat(copy): filter table pairs in MigrateMetadata for --skip-existing`** — Data-channel filter. Covers the CopyModeTable + `--dest-table` flow that bypasses `RetrieveAndProcessTables` entirely.

5. **`feat(meta): report and persist tables bypassed by --skip-existing`** — Observability. Emits a single end-of-run summary line by reason (`exists` / `root_exists` / `half_built_leaf`) and writes the full set of bypassed tables to `~/gpAdminLogs/<timestamp>_skip_existing.list`. The list is tab-separated, one line per table, embedding the db name in each FQN — multi-database copies (`--full` or `--dbname db1,db2`) can be audited unambiguously.

6. **`test(end_to_end): add happy-path E2E coverage for --skip-existing`** — Two Ginkgo cases in the existing `end_to_end_test` style: a regular table that exists on the destination retains its prior data (not overwritten), and a partition tree whose root exists on the destination is skipped entirely. The wider scenario matrix (GP6-classical-partition layout, schema-mapping interactions, half-built leaf state, external partition suffix, combinations with `--metadata-only` and `--validate`) is left as follow-up so this PR stays reviewable.

7. **`test(meta): scope the operating.System.CurrentUser swap to its field`** — Test-only fixup. The previous commit's roundtrip test was capturing `operating.System` (a `*SystemFunctions` pointer) for "restore", which is a no-op because the pointer is to the same struct being mutated. The leak surfaced in the full `go test ./...` run by breaking the Ginkgo TestBackup BeforeEach. Fix: save and restore the `CurrentUser` field directly.

## Design decisions worth flagging

- **CB→CB half-built state** (root absent on dest but a leaf is present): WARN, don't fail. The existing `parallel_depend.go:130` `already exists` swallow then `ATTACH` will bind the stale leaf onto a freshly created root — same behavior as gpcopy. The WARN gives the user a chance to inspect. GP6 path is naturally safer because the inline `CREATE TABLE ... PARTITION BY (...)` is atomic and hard-errors before this state matters at filter time.

- **Existence check is by FQN only** (matches gpcopy). Column definitions are not compared. Documented in README and the `--skip-existing` help text.

- **Filter operates on dest-side FQN** (after `--schema-mapping` translation) so the existence check matches what's actually in the destination catalog.

- **Two filter points, not one**: `RetrieveAndProcessTables` covers all DDL-bearing copy modes; `MigrateMetadata` covers the CopyModeTable + `--dest-table` flow that bypasses DDL extraction. The data-channel safety filter previously proposed in `parallel_depend.go` was analyzed and found to have no real triggering race, so it's intentionally not included.

- **Pointer receiver on the three new `Option` methods**: `MarkDestTables`, `IsDestTableExisting` and `TranslateToDestFQN` take `*Option`. They semantically mutate state (writing into the inventory maps), and relying on "map header is shared, so key-level writes propagate through value receivers" works today but is fragile against any future non-reference field added to `Option`. The first review round on this PR pushed back on the original value-receiver choice; the fix is in commit `a190a40`. The 24 pre-existing value-receiver methods on `Option` are intentionally left alone in this PR (no behavior change, no scope creep) and will be unified in a follow-up PR.

- **`skip_existing.list` embeds db name in each FQN** (matching the existing `<db>.<schema>.<table>` convention used by `cbcopy_skipped` / `cbcopy_failed`) so multi-database copies can be audited unambiguously.

## Local validation

- `go build ./...` — clean
- `go test` — pass for `copy/`, `meta/builtin/`, `option/`, `utils/`, `internal/dbconn/`, `meta/builtin/toc/`, `testutils/`
- `end_to_end/` and `integration/` `BeforeSuite` fail in this environment for lack of a live cluster — the same failures reproduce on upstream `main`, so they're not introduced by this PR.
- `go vet` — the pre-existing `testutils/functions.go:648 unreachable code` warning is the only finding; it also reproduces on upstream `main`.

## Contributor's checklist

- [x] Title and commit messages follow the Conventional Commits style already used by the repo.
- [x] CLA — already signed.

