### PR TITLE
feat: partition root table support with boundary-based leaf pairing and --redistribute

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -122,6 +122,7 @@ func (app *Application) SetFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(option.COMPRESSION, false, "Enable compression for data transfer (master: snappy, segment: zstd by default)")
 	flagSet.String(option.COMPRESS_TYPE, "zstd", "Compression algorithm for segment copy: \"gzip\", \"snappy\", or \"zstd\" (master copy always uses snappy)")
 	flagSet.Int(option.ON_SEGMENT_THRESHOLD, 1000000, "Copy between Coordinators directly, if the table has smaller or same number of rows")
+	flagSet.Bool(option.COPY_ON_SEGMENT, false, "Force all tables to be copied ON SEGMENT, bypassing the --on-segment-threshold row-count check")
 	flagSet.Bool(option.QUIET, false, "Suppress non-warning, non-error log messages")
 	flagSet.String(option.SOURCE_HOST, "127.0.0.1", "The host of source cluster. Must be reachable from the destination cluster under --connection-mode pull.")
 	flagSet.Int(option.SOURCE_PORT, 5432, "The port of source cluster")
@@ -139,6 +140,7 @@ func (app *Application) SetFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool("version", false, "Print version number and exit")
 	flagSet.String(option.DATA_PORT_RANGE, "1024-65535", "The range of listening port number to choose for receiving data on dest cluster")
 	flagSet.String(option.CONNECTION_MODE, "push", "Connection mode, 'push' (source connects to dest) or 'pull' (dest connects to source)")
+	flagSet.Bool(option.REDISTRIBUTE, false, "When source and destination distribution keys differ, copy on segment in parallel and redistribute to the destination's distribution key (instead of failing). Note: when set, all segment-copied tables are redistributed, including same-key ones.")
 }
 
 // doFlagValidation validates the command-line flags and performs necessary checks.

--- a/copy/copy_command.go
+++ b/copy/copy_command.go
@@ -553,6 +553,7 @@ func createTestCopyStrategy(strategy string, workerId int, srcSegs []utils.Segme
 // - Segment copy (large tables): only uses zstd or gzip (default: zstd)
 func CreateCopyStrategy(isReplicated bool,
 	numTuples int64,
+	forceOnSegment bool,
 	workerId int,
 	srcSegs []utils.SegmentHostInfo,
 	destSegs []utils.SegmentHostInfo,
@@ -572,7 +573,9 @@ func CreateCopyStrategy(isReplicated bool,
 		return createTestCopyStrategy(strategy, workerId, srcSegs, destSegs, connectionMode, useCompression)
 	}
 
-	if numTuples <= int64(utils.MustGetFlagInt(option.ON_SEGMENT_THRESHOLD)) {
+	globalForce := utils.MustGetFlagBool(option.COPY_ON_SEGMENT)
+	if !forceOnSegment && !globalForce &&
+		numTuples <= int64(utils.MustGetFlagInt(option.ON_SEGMENT_THRESHOLD)) {
 		compArg := getCompressArg(true, useCompression)
 		return &CopyOnMaster{CopyBase: CopyBase{WorkerId: workerId, SrcSegmentsHostInfo: srcSegs, DestSegmentsHostInfo: destSegs, ConnectionMode: connectionMode, CompArg: compArg}}
 	}
@@ -583,6 +586,10 @@ func CreateCopyStrategy(isReplicated bool,
 	compArg := getCompressArg(false, useCompression)
 
 	if srcConn.Version.Equals(destConn.Version) && numSrcSegs == numDestSegs {
+		if utils.MustGetFlagBool(option.REDISTRIBUTE) {
+			gplog.Debug("--redistribute set: using ExtDestGeCopy to redistribute by destination distribution key")
+			return &ExtDestGeCopy{CopyBase: CopyBase{WorkerId: workerId, SrcSegmentsHostInfo: srcSegs, DestSegmentsHostInfo: destSegs, ConnectionMode: connectionMode, CompArg: compArg}}
+		}
 		return &CopyOnSegment{CopyBase: CopyBase{WorkerId: workerId, SrcSegmentsHostInfo: srcSegs, DestSegmentsHostInfo: destSegs, ConnectionMode: connectionMode, CompArg: compArg}}
 	}
 

--- a/copy/copy_manager.go
+++ b/copy/copy_manager.go
@@ -3,6 +3,7 @@ package copy
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/cloudberry-contrib/cbcopy/internal/dbconn"
@@ -171,6 +172,12 @@ func (tc *TableCopier) cleanupAfterCopy(isSkipped bool, inTxn bool, err error) {
 		tc.copiedMap[tablePath] = COPY_FAILED
 		utils.WriteDataFile(tc.manager.fFailed, tc.manager.srcConn.DBName+"."+tc.srcTable.Schema+"."+tc.srcTable.Name+"\n")
 		gplog.Error("[Worker %v] Failed to copy table %v: %v", tc.workerID, tablePath, err)
+		if strings.Contains(err.Error(), "distribution key") &&
+			strings.Contains(err.Error(), "belong to segment") {
+			gplog.Error("[Worker %v] Table %v: source and destination distribution keys differ. "+
+				"Re-run with --redistribute to copy on segment and redistribute to the destination's distribution key.",
+				tc.workerID, tablePath)
+		}
 
 		tc.rollback(inTxn)
 		return
@@ -184,6 +191,7 @@ func (tc *TableCopier) cleanupAfterCopy(isSkipped bool, inTxn bool, err error) {
 func (tc *TableCopier) copyData() error {
 	command := CreateCopyStrategy(tc.srcTable.IsReplicated,
 		tc.srcTable.RelTuples,
+		tc.srcTable.ForceOnSegment,
 		tc.workerID,
 		tc.manager.srcSegmentsHostInfo,
 		tc.manager.destSegmentsIpInfo,

--- a/copy/copy_metadata.go
+++ b/copy/copy_metadata.go
@@ -191,10 +191,11 @@ func (m *MetadataManager) fillTablePairChan(srcTables, destTables []option.Table
 	for i, t := range srcTables {
 		tablec <- option.TablePair{
 			SrcTable: option.Table{
-				Schema:       t.Schema,
-				Name:         t.Name,
-				RelTuples:    t.RelTuples,
-				IsReplicated: t.IsReplicated,
+				Schema:         t.Schema,
+				Name:           t.Name,
+				RelTuples:      t.RelTuples,
+				IsReplicated:   t.IsReplicated,
+				ForceOnSegment: t.ForceOnSegment,
 			},
 			DestTable: option.Table{
 				Schema: destTables[i].Schema,

--- a/copy/copy_query.go
+++ b/copy/copy_query.go
@@ -236,6 +236,12 @@ type PartLeafTable struct {
 	RootName  string
 	LeafName  string
 	RelTuples int64
+	// Boundary is a name-independent, deterministic representation of the
+	// leaf's partition range/list bound. Two leaves with the same bound
+	// produce the same Boundary string regardless of their partition names,
+	// so it is used to pair source and destination leaves (never the
+	// _1_prt_N name suffix, which drifts after add/drop partition).
+	Boundary string
 }
 
 // GetPartitionLeafTables retrieves partition leaf tables from the database
@@ -249,7 +255,8 @@ func (qm *QueryManager) GetPartitionLeafTables(conn *dbconn.DBConn) ([]PartLeafT
 		SELECT quote_ident(n.nspname) || '.' || quote_ident(relname) AS rootname,   
  	 	quote_ident(n.nspname) || '.' || 
  	 	(SELECT quote_ident(relname) FROM pg_class WHERE oid = inhrelid ) 
- 	 	AS 	leafname, cast(reltuples as bigint) AS relTuples
+ 	 	AS 	leafname, cast(reltuples as bigint) AS relTuples,
+ 	 	coalesce((SELECT pg_get_expr(relpartbound, oid) FROM pg_class WHERE oid = inhrelid), '') AS boundary
 		FROM pg_class c
 		JOIN pg_inherits p
 		  ON c.oid = p.inhparent
@@ -263,11 +270,17 @@ func (qm *QueryManager) GetPartitionLeafTables(conn *dbconn.DBConn) ([]PartLeafT
 		ORDER BY n.nspname, leafname;`
 	} else {
 		query = `
-		SELECT quote_ident(na.nspname) || '.' || quote_ident(cb.relname) AS rootname, quote_ident(pc.schema) ||'.' || quote_ident(pc.name) AS leafname, pc.relTuples
+		SELECT quote_ident(na.nspname) || '.' || quote_ident(cb.relname) AS rootname, quote_ident(pc.schema) ||'.' || quote_ident(pc.name) AS leafname, pc.relTuples, pc.boundary
 		FROM pg_namespace na
 		JOIN pg_class cb ON na.oid = cb.relnamespace
 		JOIN (SELECT
-		           p.parrelid AS parentid, n.nspname AS schema, cparent.relname AS name, cast(cparent.reltuples as bigint) AS relTuples
+		           p.parrelid AS parentid, n.nspname AS schema, cparent.relname AS name, cast(cparent.reltuples as bigint) AS relTuples,
+		           coalesce(r.parisdefault::text,'') || '|' ||
+		           coalesce(r.parrangestartincl::text,'') || '|' ||
+		           coalesce(r.parrangeendincl::text,'') || '|' ||
+		           coalesce(r.parrangestart::text,'') || '|' ||
+		           coalesce(r.parrangeend::text,'') || '|' ||
+		           coalesce(r.parlistvalues::text,'') AS boundary
 		          FROM pg_partition p
 		              JOIN pg_partition_rule r ON p.oid = r.paroid
 		              JOIN pg_class cparent ON cparent.oid = r.parchildrelid

--- a/copy/copy_query_wrapper.go
+++ b/copy/copy_query_wrapper.go
@@ -459,8 +459,125 @@ func (qw *QueryWrapper) GetPartitionLeafTables(conn *dbconn.DBConn, isDest bool)
 	return tables, nil
 }
 
+// leavesByRoot returns the partition leaf tables whose root equals rootFqn.
+func leavesByRoot(leaves []PartLeafTable, rootFqn string) []PartLeafTable {
+	results := make([]PartLeafTable, 0)
+	for _, l := range leaves {
+		if l.RootName == rootFqn {
+			results = append(results, l)
+		}
+	}
+	return results
+}
+
+// pairPartitionLeaves attempts to pair the source partition root's leaves to
+// the destination partition root's leaves by their range/list boundary
+// (NEVER by partition name or _1_prt_N ordinal, which drift after add/drop
+// partition and would silently route data into the wrong partition).
+//
+// It returns one source/destination option.Table per matched leaf together
+// with paired=true only when EVERY source leaf maps to exactly one
+// destination leaf with an identical boundary and vice versa. Any ambiguity
+// (duplicate boundaries, differing leaf counts, an unmatched boundary, or a
+// plain non-partitioned destination with no leaves) yields paired=false so
+// the caller falls back to the safe root->root ON SEGMENT copy.
+func (qw *QueryWrapper) pairPartitionLeaves(srcConn, destConn *dbconn.DBConn,
+	srcRoot option.Table, srcRootFqn, destRootFqn string) ([]option.Table, []option.Table, bool) {
+
+	srcLeavesAll, err := qw.GetPartitionLeafTables(srcConn, false)
+	if err != nil {
+		gplog.Debug("leaf pairing for \"%v\": cannot read source leaves (%v); falling back to root->root", srcRootFqn, err)
+		return nil, nil, false
+	}
+	destLeavesAll, err := qw.GetPartitionLeafTables(destConn, true)
+	if err != nil {
+		gplog.Debug("leaf pairing for \"%v\": cannot read dest leaves (%v); falling back to root->root", destRootFqn, err)
+		return nil, nil, false
+	}
+
+	srcLeaves := leavesByRoot(srcLeavesAll, srcRootFqn)
+	destLeaves := leavesByRoot(destLeavesAll, destRootFqn)
+
+	if len(srcLeaves) == 0 || len(destLeaves) == 0 {
+		gplog.Debug("leaf pairing for \"%v\"->\"%v\": src leaves=%v dest leaves=%v; falling back to root->root",
+			srcRootFqn, destRootFqn, len(srcLeaves), len(destLeaves))
+		return nil, nil, false
+	}
+
+	if len(srcLeaves) != len(destLeaves) {
+		gplog.Debug("leaf pairing for \"%v\"->\"%v\": leaf count mismatch (%v vs %v); falling back to root->root",
+			srcRootFqn, destRootFqn, len(srcLeaves), len(destLeaves))
+		return nil, nil, false
+	}
+
+	destByBoundary := make(map[string]PartLeafTable, len(destLeaves))
+	for _, d := range destLeaves {
+		if d.Boundary == "" {
+			gplog.Debug("leaf pairing for \"%v\"->\"%v\": dest leaf \"%v\" has empty boundary; falling back to root->root",
+				srcRootFqn, destRootFqn, d.LeafName)
+			return nil, nil, false
+		}
+		if _, dup := destByBoundary[d.Boundary]; dup {
+			gplog.Debug("leaf pairing for \"%v\"->\"%v\": duplicate dest boundary; falling back to root->root",
+				srcRootFqn, destRootFqn)
+			return nil, nil, false
+		}
+		destByBoundary[d.Boundary] = d
+	}
+
+	leafSrc := make([]option.Table, 0, len(srcLeaves))
+	leafDst := make([]option.Table, 0, len(srcLeaves))
+	seenSrcBoundary := make(map[string]bool, len(srcLeaves))
+
+	for _, s := range srcLeaves {
+		if s.Boundary == "" {
+			gplog.Debug("leaf pairing for \"%v\"->\"%v\": src leaf \"%v\" has empty boundary; falling back to root->root",
+				srcRootFqn, destRootFqn, s.LeafName)
+			return nil, nil, false
+		}
+		if seenSrcBoundary[s.Boundary] {
+			gplog.Debug("leaf pairing for \"%v\"->\"%v\": duplicate src boundary; falling back to root->root",
+				srcRootFqn, destRootFqn)
+			return nil, nil, false
+		}
+		seenSrcBoundary[s.Boundary] = true
+
+		d, ok := destByBoundary[s.Boundary]
+		if !ok {
+			gplog.Debug("leaf pairing for \"%v\"->\"%v\": src leaf \"%v\" boundary has no dest match; falling back to root->root",
+				srcRootFqn, destRootFqn, s.LeafName)
+			return nil, nil, false
+		}
+
+		ss := strings.Split(s.LeafName, ".")
+		ds := strings.Split(d.LeafName, ".")
+		if len(ss) != 2 || len(ds) != 2 {
+			gplog.Debug("leaf pairing for \"%v\"->\"%v\": unexpected leaf name format; falling back to root->root",
+				srcRootFqn, destRootFqn)
+			return nil, nil, false
+		}
+
+		leafSrc = append(leafSrc, option.Table{
+			Schema:    ss[0],
+			Name:      ss[1],
+			Partition: 0,
+			RelTuples: s.RelTuples,
+		})
+		leafDst = append(leafDst, option.Table{
+			Schema:    ds[0],
+			Name:      ds[1],
+			Partition: 0,
+			RelTuples: s.RelTuples,
+		})
+		gplog.Debug("leaf pair by boundary: \"%v\" -> \"%v\" (reltuples=%v)", s.LeafName, d.LeafName, s.RelTuples)
+	}
+
+	return leafSrc, leafDst, true
+}
+
 // excludeTablePair excludes table pairs based on source and destination tables
-func (qw *QueryWrapper) excludeTablePair(srcTables, destTables, exclTables []option.Table,
+func (qw *QueryWrapper) excludeTablePair(srcConn, destConn *dbconn.DBConn,
+	srcTables, destTables, exclTables []option.Table,
 	userTables map[string]option.TableStatistics, dbname string) ([]option.Table, []option.Table) {
 
 	if len(srcTables) != len(destTables) {
@@ -470,6 +587,13 @@ func (qw *QueryWrapper) excludeTablePair(srcTables, destTables, exclTables []opt
 	excludedSrcTabs := make([]option.Table, 0)
 	excludedDstTabs := make([]option.Table, 0)
 	tabMap := make(map[string]string)
+
+	// Build source table info map for partition root lookup
+	srcTabInfo := make(map[string]option.Table)
+	for _, t := range srcTables {
+		k := t.Schema + "." + t.Name
+		srcTabInfo[k] = t
+	}
 
 	// Build table mapping
 	for i, t := range srcTables {
@@ -488,6 +612,41 @@ func (qw *QueryWrapper) excludeTablePair(srcTables, destTables, exclTables []opt
 	for k, v := range tabMap {
 		u, exists := userTables[k]
 		if !exists {
+			// Check if it's a partition root table
+			if srcTab, ok := srcTabInfo[k]; ok && srcTab.Partition == 1 {
+				sls := strings.Split(k, ".")
+				sld := strings.Split(v, ".")
+
+				// Prefer per-leaf parallelism: pair source leaves to
+				// destination leaves by their (name-independent) range
+				// boundary and expand into one task per leaf.
+				leafSrc, leafDst, paired := qw.pairPartitionLeaves(srcConn, destConn, srcTab, k, v)
+				if paired {
+					excludedSrcTabs = append(excludedSrcTabs, leafSrc...)
+					excludedDstTabs = append(excludedDstTabs, leafDst...)
+					gplog.Info("mapping partition root \"%v\" to \"%v\" as %v leaf->leaf pair(s) by range boundary", k, v, len(leafSrc))
+					continue
+				}
+
+				// Fallback: root->root forced ON SEGMENT
+				excludedSrcTabs = append(excludedSrcTabs, option.Table{
+					Schema:         sls[0],
+					Name:           sls[1],
+					Partition:      1,
+					RelTuples:      srcTab.RelTuples,
+					ForceOnSegment: true,
+				})
+				excludedDstTabs = append(excludedDstTabs, option.Table{
+					Schema:    sld[0],
+					Name:      sld[1],
+					Partition: 0,
+					RelTuples: srcTab.RelTuples,
+				})
+
+				gplog.Debug("mapping partition root table (root->root ON SEGMENT) from \"%v\" to \"%v\"", k, v)
+				continue
+			}
+
 			gplog.Warn("Relation \"%v\" does not exists on source database \"%v\"", k, dbname)
 			continue
 		}
@@ -571,6 +730,7 @@ func (qw *QueryWrapper) processDestinationTables(srcConn, destConn *dbconn.DBCon
 	config.ValidateDestTables(destTables, destConn.DBName)
 
 	excludedSrcTabs, excludedDstTabs := qw.excludeTablePair(
+		srcConn, destConn,
 		config.GetIncludeTablesByDb(srcConn.DBName),
 		config.GetDestTablesByDb(destConn.DBName),
 		config.GetExclTablesByDb(srcConn.DBName),

--- a/option/option.go
+++ b/option/option.go
@@ -36,6 +36,7 @@ const (
 	COMPRESSION             = "compression"
 	COMPRESS_TYPE           = "compress-type"
 	ON_SEGMENT_THRESHOLD    = "on-segment-threshold"
+	COPY_ON_SEGMENT         = "copy-on-segment"
 	QUIET                   = "quiet"
 	SOURCE_HOST             = "source-host"
 	SOURCE_PORT             = "source-port"
@@ -53,6 +54,7 @@ const (
 	VERBOSE                 = "verbose"
 	DATA_PORT_RANGE         = "data-port-range"
 	CONNECTION_MODE         = "connection-mode"
+	REDISTRIBUTE            = "redistribute"
 )
 
 const (
@@ -90,6 +92,11 @@ type Table struct {
 	Partition    int
 	RelTuples    int64
 	IsReplicated bool
+
+	// ForceOnSegment skips the row-count threshold check and forces the table
+	// to be copied ON SEGMENT (used for partition root tables and when the user
+	// passes --copy-on-segment).
+	ForceOnSegment bool
 }
 
 type TablePair struct {
@@ -572,7 +579,8 @@ func (o Option) GetTablespaceMap() map[string]string {
 func (o Option) validatePartTables(title string, tables []*DbTable, userTables map[string]TableStatistics, dbname string) {
 	for _, t := range tables {
 		if t.Partition == 1 {
-			gplog.Fatal(errors.Errorf("Found partition root table: %s.%s.%s in %s list", dbname, t.Schema, t.Name, title), "")
+			// Partition root tables are allowed; they will be expanded to child partitions later.
+			continue
 		}
 
 		k := t.Schema + "." + t.Name
@@ -593,7 +601,20 @@ func (o Option) ValidateExcludeTables(userTables map[string]TableStatistics, dbn
 }
 
 func (o Option) ValidateDestTables(userTables map[string]TableStatistics, dbname string) {
-	o.validatePartTables("dest table", o.destTables, userTables, dbname)
+	for _, t := range o.destTables {
+		if t.Partition == 1 {
+			// Partition root tables are allowed as dest tables;
+			// COPY INTO a partitioned table routes data to child partitions.
+			continue
+		}
+
+		k := t.Schema + "." + t.Name
+
+		_, exists := userTables[k]
+		if !exists {
+			gplog.Fatal(errors.Errorf("dest table \"%v\" does not exists on \"%v\" database", k, dbname), "")
+		}
+	}
 }
 
 func MakeIncludeOptions(initialFlags *pflag.FlagSet, testTableName string) {


### PR DESCRIPTION
Closed: splitting into two separate PRs for easier review.

- PR A: partition root table support (feat/partition-root-support)
- PR B: --redistribute + --hetero-table (to be submitted separately)