### PR TITLE
fix(helper): don't let the accept deadline bound the whole transfer (#44)

### DIFF
--- a/helper/server.go
+++ b/helper/server.go
@@ -130,21 +130,33 @@ func (t *ServerBase) Serve() {
 func (t *ServerBase) serve() {
 	defer t.wg.Done()
 
-	for {
+	var accepted int32
+	for accepted < t.numConn {
 		conn, err := t.listener.Accept()
 		if err != nil {
 			select {
 			case <-t.quit:
 				return
 			default:
+				// Reaching here means not all expected clients connected
+				// before the listener's accept deadline/error fired. That is
+				// a real, fatal error for the accept phase. Return instead of
+				// continuing so we never busy-spin on an already-tripped
+				// deadline (issue #44).
 				gplog.Error("Listener.Accept() failed: %v", err)
 				t.setError(err)
+				return
 			}
-			continue
 		}
 
+		accepted++
 		t.handler.handleConnection(conn)
 	}
+
+	// All expected clients are connected. Stop letting the listener's accept
+	// deadline bound the rest of the transfer: close the listener so the
+	// in-flight data connections stream to completion with no timeout (issue #44).
+	_ = t.listener.Close()
 }
 
 func (t *ServerBase) Err() error {

--- a/helper/server.go
+++ b/helper/server.go
@@ -156,7 +156,15 @@ func (t *ServerBase) serve() {
 	// All expected clients are connected. Stop letting the listener's accept
 	// deadline bound the rest of the transfer: close the listener so the
 	// in-flight data connections stream to completion with no timeout (issue #44).
-	_ = t.listener.Close()
+	if err := t.listener.Close(); err != nil {
+		// Benign at this point: all expected clients are already connected and
+		// streaming, so a listener-close failure does not affect the transfer.
+		// Deliberately do NOT setError here -- failing an otherwise-healthy
+		// transfer on this would reintroduce the class of spurious teardown
+		// that issue #44 is about. Log for visibility only.
+		gplog.Debug("Failed to close listener after accept phase, seg-id %v cmd-id %v: %v",
+			t.config.SegID, t.config.CmdID, err)
+	}
 }
 
 func (t *ServerBase) Err() error {


### PR DESCRIPTION
fix #44

---

## Change logs

`ConcurrentServer.serve()` runs an unbounded `Accept()` loop that lives for the whole transfer. The listener's absolute 600 s deadline (set in `ServerBase.Start()`) therefore bounds the **total transfer time** of a single table, not just the accept phase: once all expected clients (`--client-numbers`) have connected, the loop blocks on `Accept()` again, and at start + 600 s that still-blocked `Accept()` returns `i/o timeout` → `setError` → the transfer is torn down. This is confined to `ExtDestLtCopy` + push (destination has fewer segments than source), i.e. any table whose data takes longer than ~10 minutes to move. See #44 for the full root-cause analysis.

**Fix:** make `serve()` accept-count aware — stop accepting once `numConn` connections are in, then `Close()` the listener so the in-flight data connections stream to completion with no listener deadline over them. A timeout/error *before* all expected clients have connected is still fatal (a client genuinely failed to connect), and the error path now `return`s instead of `continue`-ing, so a tripped deadline can no longer busy-spin flooding the log.

**Scope:** only `ConcurrentServer` (`ExtDestLtCopy` + push) is affected. `OneTimeServer` (`CopyOnMaster` / `CopyOnSegment` / `ExtDestGeCopy` and all pull-mode senders) closes its listener after a single `Accept()` and is unchanged — so `--connection-mode=pull` was, and remains, unaffected.

## Validation

On a 16 → 8 segment setup (source 16 primaries, destination 8) copying a single large unpartitioned table (TPC-DS `store_sales`, 1 TB scale) in default push mode:

- The pre-fix helper reproduces #44 at exactly start + 600 s — as an abort (`could not write to COPY program: Broken pipe` on the source; `22P04` / `25M01` on the destination) and, depending on timing, as an indefinite hang with no error surfaced to either side.
- After rebuilding just the receive-side helper with this change and re-running the same copy, it ran well past the 600 s cap and completed normally (`successfully copied 1 tables`, total elapsed 36m52s), with **zero** `Listener.Accept() ... i/o timeout` on the destination helpers.

The `helper` package currently has no unit tests; happy to add a focused `serve()` test (accept `numConn` → listener closed, `Err()==nil`, no timeout; fewer than `numConn` before the deadline → `Err()!=nil`, no busy-spin) if maintainers would like one in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server listeners now stop accepting connections after the expected number of clients connect.
  * Accept errors now terminate the connection-acceptance process promptly instead of being ignored.
  * Listeners close automatically once all expected connections are established, while existing connections remain active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->