### PR TITLE
Go: bump go to 1.25

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: "1.25"
 
     - name: Build
       run: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: "1.25"
 
       - name: Build binaries
         run: CGO_ENABLED=0 make

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -384,7 +384,7 @@ func (app *Application) doTeardown() {
 	if err := recover(); err != nil {
 		// gplog's Fatal will cause a panic with error code 2
 		if gplog.GetErrorCode() != 2 {
-			gplog.Error(fmt.Sprintf("%v: %s", err, debug.Stack()))
+			gplog.Error("%v: %s", err, debug.Stack())
 			gplog.SetErrorCode(2)
 		} else {
 			errStr = fmt.Sprintf("%v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudberry-contrib/cbcopy
 
-go 1.21
+go 1.25.0
 
 // gpbackup update,
 // https://github.com/greenplum-db/gpbackup/commit/24797490747fdd4ae648f6da5cbaf2aed8284216

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -367,7 +367,7 @@ func (executor *GPDBExecutor) ExecuteClusterCommand(scope Scope, commandList []S
  *    - e.g. running multiple scps on coordinator to push a file to all segments
  */
 func (cluster *Cluster) GenerateAndExecuteCommand(verboseMsg string, scope Scope, generator interface{}) *RemoteOutput {
-	gplog.Verbose(verboseMsg)
+	gplog.Verbose("%s", verboseMsg)
 	commandList := cluster.GenerateSSHCommandList(scope, generator)
 	return cluster.ExecuteClusterCommand(scope, commandList)
 }
@@ -391,7 +391,7 @@ func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMs
 	}
 
 	if len(noFatal) == 1 && noFatal[0] == true {
-		gplog.Error(finalErrMsg)
+		gplog.Error("%s", finalErrMsg)
 	} else {
 		LogFatalClusterError(finalErrMsg, remoteOutput.Scope, remoteOutput.NumErrors)
 	}

--- a/meta/builtin/predata_functions.go
+++ b/meta/builtin/predata_functions.go
@@ -382,7 +382,7 @@ func PrintCreateTransformStatement(metadataFile *utils.FileWithByteCount, toc *t
 	TypeFQN := fmt.Sprintf("%s.%s", transform.TypeNamespace, transform.TypeName)
 
 	if !fromSQLIsDefined && !toSQLIsDefined {
-		gplog.Warn(fmt.Sprintf("Skipping invalid transform object for type %s and language %s; At least one of FROM and TO functions should be specified.", TypeFQN, transform.LanguageName))
+		gplog.Warn("Skipping invalid transform object for type %s and language %s; At least one of FROM and TO functions should be specified.", TypeFQN, transform.LanguageName)
 		return
 	}
 	start := metadataFile.ByteCount
@@ -390,7 +390,7 @@ func PrintCreateTransformStatement(metadataFile *utils.FileWithByteCount, toc *t
 	if fromSQLIsDefined {
 		statement += fmt.Sprintf("FROM SQL WITH FUNCTION %s", fromSQLFunc.FQN())
 	} else {
-		gplog.Warn(fmt.Sprintf("No FROM function found for transform object with type %s and language %s\n", TypeFQN, transform.LanguageName))
+		gplog.Warn("No FROM function found for transform object with type %s and language %s\n", TypeFQN, transform.LanguageName)
 	}
 
 	if toSQLIsDefined {
@@ -399,10 +399,10 @@ func PrintCreateTransformStatement(metadataFile *utils.FileWithByteCount, toc *t
 		}
 		statement += fmt.Sprintf("TO SQL WITH FUNCTION %s", toSQLFunc.FQN())
 	} else {
-		gplog.Warn(fmt.Sprintf("No TO function found for transform object with type %s and language %s\n", TypeFQN, transform.LanguageName))
+		gplog.Warn("No TO function found for transform object with type %s and language %s\n", TypeFQN, transform.LanguageName)
 	}
 	statement += ");"
-	metadataFile.MustPrintf(statement)
+	metadataFile.MustPrintf("%s", statement)
 	section, entry := transform.GetMetadataEntry()
 	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, transformMetadata, transform, "")

--- a/meta/builtin/queries_acl.go
+++ b/meta/builtin/queries_acl.go
@@ -139,7 +139,7 @@ type MetadataQueryStruct struct {
 }
 
 func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQueryParams) MetadataMap {
-	gplog.Verbose("Getting object type metadata from " + params.CatalogTable)
+	gplog.Verbose("Getting object type metadata from %s", params.CatalogTable)
 
 	tableName := params.CatalogTable
 	nameCol := "''"

--- a/meta/builtin/restore_helper.go
+++ b/meta/builtin/restore_helper.go
@@ -120,7 +120,7 @@ func RestoreSchemas(conn *dbconn.DBConn, schemaStatements []toc.StatementWithTyp
 			if strings.Contains(err.Error(), "already exists") {
 			} else {
 				errMsg := fmt.Sprintf("Error encountered while creating schema %s", schema.Name)
-				gplog.Verbose(fmt.Sprintf("%s: %s", errMsg, err.Error()))
+				gplog.Verbose("%s: %s", errMsg, err.Error())
 				numErrors++
 			}
 		}


### PR DESCRIPTION
Bumps cbcopy to Go 1.25, aligning with `apache/cloudberry-backup` and `apache/cloudberry-go-libs` (both on `go 1.25.0`).

## Changes

- **`go.mod`**: `go 1.21` → `go 1.25.0` (matches sibling repos; no `toolchain` line, same as them)
- **CI** (`build_and_unit_test.yml`, `release.yml`): `actions/setup-go@v4` → `@v5`, `go-version: 1.21` → `"1.25"`
- **printf fixes (9 sites)**: Go 1.24 taught vet's printf analyzer to flag non-constant format strings. Since `go test` runs vet, this broke `make unit` (the `builtin` suite failed to compile). Converted the affected `gplog.Warn/Verbose/Error` and `MustPrintf` calls to printf-style (explicit format string + args). Passing the message through `%s` also fixes latent mis-formatting when a message itself contains `%`.
  - `meta/builtin/{predata_functions,queries_acl,restore_helper}.go` — 6 sites (these blocked `make unit`)
  - `copy/copy.go`, `internal/cluster/cluster.go` — 3 sites (not in CI's test dirs, but flagged by `go vet ./...`; fixed for a clean bump)

## Verification

Ran locally against `go version go1.25.0 linux/amd64`:

- `go build ./...` — clean
- `go vet ./...` — 0 warnings
- `make` — builds `cbcopy` + `cbcopy_helper`
- `make unit` — all 5 suites pass

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.25 for builds, tests, releases, and project configuration.

* **Bug Fixes**
  * Improved diagnostic and warning logging during command execution, cluster checks, schema restoration, transform generation, and error recovery.
  * Preserved existing error handling and operational behavior while improving log formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->