### PR TITLE
test: remove unreachable code in GetServerVersion (#48)

### DIFF
--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -638,18 +638,6 @@ func GetServerVersion(host string, port int, user string) string {
 	serverVersion := strings.TrimSpace(string(out))
 
 	return serverVersion
-
-	/*
-		PostgreSQL 9.4.26 (Greenplum Database 6.20.0 build 9999) (HashData Warehouse 3.13.8 build 27594) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 10.2.1 20210130 (Red Hat 10.2.1-11), 64-bit compiled on Feb 10 2023 17:22:03
-
-		PostgreSQL 14.4 (Apache Cloudberry 1.2.0 build commit:5b5ae3f8aa638786f01bbd08307b6474a1ba1997) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 10.2.1 20210130 (Red Hat 10.2.1-11), 64-bit compiled on Feb 16 2023 23:44:39
-	*/
-
-	re := regexp.MustCompile(`\d+\.\d+(\.\d+)?`)
-	match := re.FindString(serverVersion)
-	//fmt.Println(match)
-
-	return match
 }
 
 func GetPslVersion() string {


### PR DESCRIPTION
## What

Removes the unreachable code block at the end of `GetServerVersion` in `testutils/functions.go`.

## Why

`go vet ./...` reports one warning on `main`:

```
# github.com/cloudberry-contrib/cbcopy/testutils
testutils/functions.go:648:2: unreachable code
```

`GetServerVersion` returns `serverVersion` early, so the trailing regexp-extraction block (a comment block + `regexp.MustCompile` + `return match`) is dead code — never executed. The function has **no callers** in the repo, so there is no intended behavior to preserve; the safe, minimal fix is to drop the unreachable block.

## Verification

- `gofmt -l` — clean
- `go vet ./...` — **now clean** (warning gone)
- `go build ./...` — passes
- `make unit` — all 5 suites pass (dbconn 12/12, backup 469/470 + skips, TOC 45/45, testutils 8/8, utils 58/58)

`regexp` is still imported and used by the sibling `GetPslVersion`, so no import change is needed. No behavior change.

Fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server version reporting by preserving the complete version output returned by the database client.
  * Removed unnecessary version parsing that could omit non-numeric version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->